### PR TITLE
Enable Jtreg test suites for FFI on Power & zLinux in JDK21

### DIFF
--- a/test/jdk/java/foreign/TestAddressDereference.java
+++ b/test/jdk/java/foreign/TestAddressDereference.java
@@ -22,10 +22,17 @@
  */
 
 /*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ */
+
+/*
  * @test
  * @enablePreview
  * @library ../ /test/lib
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64" | os.arch == "riscv64"
+ * | os.arch == "ppc64" | os.arch == "ppc64le" | os.arch == "s390x"
  * @run testng/othervm --enable-native-access=ALL-UNNAMED TestAddressDereference
  */
 

--- a/test/jdk/java/foreign/TestClassLoaderFindNative.java
+++ b/test/jdk/java/foreign/TestClassLoaderFindNative.java
@@ -23,7 +23,7 @@
 
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2022, 2022 All Rights Reserved
+ * (c) Copyright IBM Corp. 2022, 2023 All Rights Reserved
  * ===========================================================================
  */
 
@@ -40,6 +40,7 @@ import java.lang.foreign.SymbolLookup;
 import org.testng.annotations.Test;
 
 import static java.lang.foreign.ValueLayout.JAVA_BYTE;
+import static java.lang.foreign.ValueLayout.JAVA_INT;
 import static org.testng.Assert.*;
 
 // FYI this test is run on 64-bit platforms only for now,
@@ -64,13 +65,13 @@ public class TestClassLoaderFindNative {
 
     @Test
     public void testVariableSymbolLookup() {
-        MemorySegment segment = SymbolLookup.loaderLookup().find("c").get().reinterpret(1);
+        MemorySegment segment = SymbolLookup.loaderLookup().find("c").get().reinterpret(JAVA_INT.byteSize());
         /* JAVA_INT applies to both Little-Endian and Big-Endian
          * platforms given the one-byte int value is stored at the
          * highest address(offset 3) of the int type in native on
          * the Big-Endian platforms.
          * See libLookupTest.c
          */
-        assertEquals(segment.get(ValueLayout.JAVA_INT, 0), 42);
+        assertEquals(segment.get(JAVA_INT, 0), 42);
     }
 }

--- a/test/jdk/java/foreign/TestIntrinsics.java
+++ b/test/jdk/java/foreign/TestIntrinsics.java
@@ -22,9 +22,16 @@
  */
 
 /*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ */
+
+/*
  * @test
  * @enablePreview
  * @requires os.arch=="amd64" | os.arch=="x86_64" | os.arch=="aarch64" | os.arch=="riscv64"
+ * | os.arch == "ppc64" | os.arch == "ppc64le" | os.arch == "s390x"
  * @run testng/othervm
  *   -Djdk.internal.foreign.DowncallLinker.USE_SPEC=true
  *   --enable-native-access=ALL-UNNAMED

--- a/test/jdk/java/foreign/TestLinker.java
+++ b/test/jdk/java/foreign/TestLinker.java
@@ -22,9 +22,16 @@
  */
 
 /*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ */
+
+/*
  * @test
  * @enablePreview
  * @requires os.arch=="amd64" | os.arch=="x86_64" | os.arch=="aarch64" | os.arch=="riscv64"
+ * | os.arch == "ppc64" | os.arch == "ppc64le" | os.arch == "s390x"
  * @run testng TestLinker
  */
 

--- a/test/jdk/java/foreign/TestVarArgs.java
+++ b/test/jdk/java/foreign/TestVarArgs.java
@@ -24,7 +24,7 @@
 
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2022, 2022 All Rights Reserved
+ * (c) Copyright IBM Corp. 2022, 2023 All Rights Reserved
  * ===========================================================================
  */
 
@@ -192,7 +192,7 @@ public class TestVarArgs extends CallGeneratorHelper {
              * address in java on the Big-Endian(BE) platforms such as AIX.
              */
             if (isAixOS && (layout instanceof ValueLayout) && (((ValueLayout)layout).carrier() == float.class)) {
-                MemorySegment doubleSegmt = MemorySegment.ofAddress(ptr, JAVA_DOUBLE.byteSize(), session);
+                MemorySegment doubleSegmt = MemorySegment.ofAddress(ptr.address()).reinterpret(JAVA_DOUBLE.byteSize());
                 seg.set(JAVA_FLOAT, 0, (float)doubleSegmt.get(JAVA_DOUBLE, 0));
             }
             Object obj = getter.invoke(seg);

--- a/test/jdk/java/foreign/arraystructs/TestArrayStructs.java
+++ b/test/jdk/java/foreign/arraystructs/TestArrayStructs.java
@@ -22,10 +22,17 @@
  */
 
 /*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ */
+
+/*
  * @test id=specialized
  * @enablePreview
  * @library ../
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64" | os.arch == "riscv64"
+ * | os.arch == "ppc64" | os.arch == "ppc64le" | os.arch == "s390x"
  * @modules java.base/jdk.internal.foreign
  * @run testng/othervm
  *   --enable-native-access=ALL-UNNAMED
@@ -39,6 +46,7 @@
  * @enablePreview
  * @library ../
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64" | os.arch == "riscv64"
+ * | os.arch == "ppc64" | os.arch == "ppc64le" | os.arch == "s390x"
  * @modules java.base/jdk.internal.foreign
  * @run testng/othervm
  *   --enable-native-access=ALL-UNNAMED

--- a/test/jdk/java/foreign/capturecallstate/TestCaptureCallState.java
+++ b/test/jdk/java/foreign/capturecallstate/TestCaptureCallState.java
@@ -26,6 +26,7 @@
  * @enablePreview
  * @library ../ /test/lib
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64" | os.arch == "riscv64"
+ * | os.arch == "ppc64" | os.arch == "ppc64le" | os.arch == "s390x"
  * @run testng/othervm --enable-native-access=ALL-UNNAMED TestCaptureCallState
  */
 

--- a/test/jdk/java/foreign/dontrelease/TestDontRelease.java
+++ b/test/jdk/java/foreign/dontrelease/TestDontRelease.java
@@ -22,11 +22,18 @@
  */
 
 /*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ */
+
+/*
  * @test
  * @enablePreview
  * @library ../ /test/lib
  * @modules java.base/jdk.internal.ref java.base/jdk.internal.foreign
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64" | os.arch == "riscv64"
+ * | os.arch == "ppc64" | os.arch == "ppc64le" | os.arch == "s390x"
  * @run testng/othervm --enable-native-access=ALL-UNNAMED TestDontRelease
  */
 

--- a/test/jdk/java/foreign/enablenativeaccess/TestEnableNativeAccessDynamic.java
+++ b/test/jdk/java/foreign/enablenativeaccess/TestEnableNativeAccessDynamic.java
@@ -22,9 +22,16 @@
  */
 
 /*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ */
+
+/*
  * @test
  * @enablePreview
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64" | os.arch == "riscv64"
+ * | os.arch == "ppc64" | os.arch == "ppc64le" | os.arch == "s390x"
  * @requires !vm.musl
  *
  * @library /test/lib

--- a/test/jdk/java/foreign/largestub/TestLargeStub.java
+++ b/test/jdk/java/foreign/largestub/TestLargeStub.java
@@ -22,10 +22,17 @@
  */
 
 /*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ */
+
+/*
  * @test
  * @enablePreview
  * @library ../
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64" | os.arch == "riscv64"
+ * | os.arch == "ppc64" | os.arch == "ppc64le" | os.arch == "s390x"
  * @modules java.base/jdk.internal.foreign
  * @run testng/othervm --enable-native-access=ALL-UNNAMED TestLargeStub
  */

--- a/test/jdk/java/foreign/nested/TestNested.java
+++ b/test/jdk/java/foreign/nested/TestNested.java
@@ -22,10 +22,17 @@
  */
 
 /*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ */
+
+/*
  * @test
  * @enablePreview
  * @library ../ /test/lib
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64" | os.arch == "riscv64"
+ * | os.arch == "ppc64" | os.arch == "ppc64le" | os.arch == "s390x"
  * @requires vm.flavor != "zero"
  * @build NativeTestHelper
  * @run testng/othervm --enable-native-access=ALL-UNNAMED TestNested

--- a/test/jdk/java/foreign/normalize/TestNormalize.java
+++ b/test/jdk/java/foreign/normalize/TestNormalize.java
@@ -22,10 +22,17 @@
  */
 
 /*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ */
+
+/*
  * @test
  * @enablePreview
  * @library ../
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64" | os.arch == "riscv64"
+ * | os.arch == "ppc64" | os.arch == "ppc64le" | os.arch == "s390x"
  * @run testng/othervm
  *   --enable-native-access=ALL-UNNAMED
  *   -Xbatch

--- a/test/jdk/java/foreign/passheapsegment/TestPassHeapSegment.java
+++ b/test/jdk/java/foreign/passheapsegment/TestPassHeapSegment.java
@@ -22,10 +22,17 @@
  */
 
 /*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ */
+
+/*
  * @test
  * @enablePreview
  * @library ../ /test/lib
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64" | os.arch == "riscv64"
+ * | os.arch == "ppc64" | os.arch == "ppc64le" | os.arch == "s390x"
  * @run testng/othervm --enable-native-access=ALL-UNNAMED TestPassHeapSegment
  */
 

--- a/test/jdk/java/foreign/trivial/TestTrivial.java
+++ b/test/jdk/java/foreign/trivial/TestTrivial.java
@@ -22,10 +22,17 @@
  */
 
 /*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ */
+
+/*
  * @test
  * @enablePreview
  * @library ../ /test/lib
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64" | os.arch == "riscv64"
+ * | os.arch == "ppc64" | os.arch == "ppc64le" | os.arch == "s390x"
  * @run testng/othervm --enable-native-access=ALL-UNNAMED TestTrivial
  */
 

--- a/test/jdk/java/foreign/trivial/TestTrivialUpcall.java
+++ b/test/jdk/java/foreign/trivial/TestTrivialUpcall.java
@@ -22,10 +22,17 @@
  */
 
 /*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ */
+
+/*
  * @test
  * @enablePreview
  * @library ../ /test/lib
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64" | os.arch == "riscv64"
+ * | os.arch == "ppc64" | os.arch == "ppc64le" | os.arch == "s390x"
  * @requires vm.flavor != "zero"
  * @run testng/othervm --enable-native-access=ALL-UNNAMED TestTrivialUpcall
  */

--- a/test/jdk/java/foreign/virtual/TestVirtualCalls.java
+++ b/test/jdk/java/foreign/virtual/TestVirtualCalls.java
@@ -22,9 +22,16 @@
  */
 
 /*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ */
+
+/*
  * @test
  * @enablePreview
  * @requires os.arch=="amd64" | os.arch=="x86_64" | os.arch=="aarch64" | os.arch=="riscv64"
+ * | os.arch == "ppc64" | os.arch == "ppc64le" | os.arch == "s390x"
  * @library ../
  * @run testng/othervm
  *   --enable-native-access=ALL-UNNAMED


### PR DESCRIPTION
The changes add Power & zLinux support to these
Jtreg test suites in JDK21 plus a few compilation
fixes in the test cases to ensure they are executed
correctly on all supported platforms.

Note:
The PR is part of the FFI work at
eclipse-openj9/openj9#16951

Signed-off-by: Cheng Jin <jincheng@ca.ibm.com>
