### PR TITLE
Enable CRIU by default on Linux on AArch64

### DIFF
--- a/closed/autoconf/custom-hook.m4
+++ b/closed/autoconf/custom-hook.m4
@@ -349,7 +349,7 @@ AC_DEFUN([OPENJ9_CONFIGURE_CRIU_SUPPORT],
     AC_MSG_RESULT([no (explicitly disabled)])
   elif test "x$enable_criu_support" = x ; then
     case "$OPENJ9_PLATFORM_CODE" in
-      xa64|xz64)
+      xa64|xr64|xz64)
         AC_MSG_RESULT([yes (default)])
         OPENJ9_ENABLE_CRIU_SUPPORT=true
         ;;


### PR DESCRIPTION
See https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/619#issuecomment-1601642739.