### PR TITLE
Add OpenJ9PropsExt properties for vm.gc.ZGenerational & vm.gc.ZSinglegen

### DIFF
--- a/closed/test/jtreg-ext/requires/OpenJ9PropsExt.java
+++ b/closed/test/jtreg-ext/requires/OpenJ9PropsExt.java
@@ -49,6 +49,8 @@ public class OpenJ9PropsExt implements Callable<Map<String, String>> {
             map.put("vm.gc.Serial", "false");
             map.put("vm.gc.Shenandoah", "false");
             map.put("vm.gc.Z", "false");
+            map.put("vm.gc.ZGenerational", "false");
+            map.put("vm.gc.ZSinglegen", "false");
             map.put("vm.graal.enabled", "false");
             map.put("vm.hasJFR", "false");
             map.put("vm.jvmti", "true");


### PR DESCRIPTION
Add `OpenJ9PropsExt` properties for `vm.gc.ZGenerational` & `vm.gc.ZSinglegen`

Cherry-pick 
* https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/627

Signed-off-by: Jason Feng <fengj@ca.ibm.com>