### PR TITLE
Centralize definition of J9TOOLS_DIR and fix uses on Windows 11

### DIFF
--- a/closed/GensrcJ9JCL.gmk
+++ b/closed/GensrcJ9JCL.gmk
@@ -61,7 +61,7 @@ $(J9JCL_SOURCES_DONEFILE) : \
 	@$(MKDIR) -p $(J9TOOLS_DIR)
 	$(MAKE) $(MAKE_ARGS) -C $(OPENJ9_TOPDIR)/sourcetools -f buildj9tools.mk \
 		BOOT_JDK=$(BOOT_JDK) \
-		DEST_DIR=$(call FixPath,$(J9TOOLS_DIR)) \
+		DEST_DIR=$(call MixedPath,$(J9TOOLS_DIR)) \
 		JAVA_HOME=$(BOOT_JDK) \
 		preprocessor
 	@$(ECHO) Generating J9JCL sources

--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -27,6 +27,7 @@ ifeq (,$(wildcard $(SPEC)))
 endif
 include $(SPEC)
 include $(TOPDIR)/make/common/MakeBase.gmk
+include $(TOPDIR)/closed/JPP.gmk
 
 ifeq (,$(BUILD_ID))
   BUILD_ID := 000000
@@ -325,8 +326,6 @@ $(foreach file, \
 	$(notdir $(wildcard $(OPENJ9_TOPDIR)/buildspecs/*)), \
 	$(eval $(call openj9_stage_buildspec_file,$(file))))
 
-J9TOOLS_DIR := $(SUPPORT_OUTPUTDIR)/j9tools
-
 stage-j9 :
 	@$(ECHO) Staging OpenJ9 runtime in $(OUTPUTDIR)/vm
 	$(call openj9_copy_tree,$(OUTPUTDIR)/vm,$(OPENJ9_TOPDIR)/runtime)
@@ -497,13 +496,13 @@ run-preprocessors-j9 : stage-j9
 	+BOOT_JDK=$(BOOT_JDK) $(EXPORT_COMPILER_ENV_VARS) OPENJDK_VERSION_NUMBER_FOUR_POSITIONS=$(VERSION_NUMBER_FOUR_POSITIONS) \
 		$(MAKE) $(MAKE_ARGS) -C $(OUTPUTDIR)/vm -f $(OPENJ9_TOPDIR)/runtime/buildtools.mk \
 			BUILD_ID=$(BUILD_ID) \
-			DEST_DIR=$(call FixPath,$(J9TOOLS_DIR)) \
+			DEST_DIR=$(call MixedPath,$(J9TOOLS_DIR)) \
 			EXTRA_CONFIGURE_ARGS=$(OMR_EXTRA_CONFIGURE_ARGS) \
 			FREEMARKER_JAR="$(FREEMARKER_JAR)" \
 			J9VM_SHA=$(OPENJ9_SHA) \
 			JAVA_HOME=$(BOOT_JDK) \
 			OMR_DIR=$(OUTPUTDIR)/vm/omr \
-			SOURCETOOLS_DIR=$(call FixPath,$(OPENJ9_TOPDIR))/sourcetools \
+			SOURCETOOLS_DIR=$(call MixedPath,$(OPENJ9_TOPDIR))/sourcetools \
 			SPEC=$(OPENJ9_BUILDSPEC) \
 			UMA_OPTIONS_EXTRA="-buildDate $(shell date +'%Y%m%d')" \
 			VERSION_MAJOR=$(VERSION_FEATURE) \

--- a/closed/custom/common/MakeBase.gmk
+++ b/closed/custom/common/MakeBase.gmk
@@ -18,35 +18,17 @@
 # 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
 # ===========================================================================
 
-J9TOOLS_DIR := $(SUPPORT_OUTPUTDIR)/j9tools
-JPP_JAR     := $(J9TOOLS_DIR)/jpp.jar
-JPP_TAGS    := PLATFORM-$(OPENJ9_PLATFORM_CODE)
+# Echo a command and then execute it.
+# $1 - the command
+define EchoAndRun
+	@ $(ECHO) $1
+	@ $1
+endef
 
-ifeq (true,$(OPENJ9_ENABLE_CRIU_SUPPORT))
-  JPP_TAGS += CRIU_SUPPORT
-endif # OPENJ9_ENABLE_CRIU_SUPPORT
-
-ifeq (true,$(OPENJ9_ENABLE_INLINE_TYPES))
-  JPP_TAGS += INLINE-TYPES
-endif # OPENJ9_ENABLE_INLINE_TYPES
-
-# invoke JPP to preprocess java source files
-# $1 - configuration
-# $2 - source directory
-# $3 - destination subdirectory
-# $4 - more options (optional)
-define RunJPP
-	$(call EchoAndRun, $(BOOT_JDK)/bin/java \
-		-cp "$(call MixedPath,$(JPP_JAR))" \
-		-Dfile.encoding=US-ASCII \
-		com.ibm.jpp.commandline.CommandlineBuilder \
-			-verdict \
-			-config $1 \
-			-baseDir "$(call MixedPath,$(dir $2))" \
-			-srcRoot $(notdir $2)/ \
-			-xml "$(call MixedPath,$(OPENJ9_TOPDIR)/jcl/jpp_configuration.xml)" \
-			-dest "$(call MixedPath,$(SUPPORT_OUTPUTDIR)$(strip $3))" \
-			-tag:define "$(subst $(SPACE),;,$(sort $(JPP_TAGS)))" \
-			$4 \
-		)
-endef # RunJPP
+# On Windows, FixPath yields backslashes which can cause problems, so
+# we use PATHTOOL instead for tools (like java) that support both.
+ifeq ($(call isTargetOs, windows), true)
+  MixedPath = $(shell $(PATHTOOL) -m $1)
+else
+  MixedPath = $1
+endif


### PR DESCRIPTION
This is a back-port of https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/630.