### PR TITLE
Fix missing definition of harfbuzz function on AIX

### DIFF
--- a/src/java.desktop/share/native/libharfbuzz/hb-map.hh
+++ b/src/java.desktop/share/native/libharfbuzz/hb-map.hh
@@ -78,6 +78,10 @@ struct hb_hashmap_t
                 is_used_ (false), is_tombstone_ (false),
                 value () {}
 
+    // Needed for https://github.com/harfbuzz/harfbuzz/issues/4138
+    K& get_key () { return key; }
+    V& get_value () { return value; }
+
     bool is_used () const { return is_used_; }
     void set_used (bool is_used) { is_used_ = is_used; }
     bool is_tombstone () const { return is_tombstone_; }
@@ -339,23 +343,23 @@ struct hb_hashmap_t
   auto keys_ref () const HB_AUTO_RETURN
   (
     + iter_items ()
-    | hb_map (&item_t::key)
+    | hb_map (&item_t::get_key)
   )
   auto keys () const HB_AUTO_RETURN
   (
     + iter_items ()
-    | hb_map (&item_t::key)
+    | hb_map (&item_t::get_key)
     | hb_map (hb_ridentity)
   )
   auto values_ref () const HB_AUTO_RETURN
   (
     + iter_items ()
-    | hb_map (&item_t::value)
+    | hb_map (&item_t::get_value)
   )
   auto values () const HB_AUTO_RETURN
   (
     + iter_items ()
-    | hb_map (&item_t::value)
+    | hb_map (&item_t::get_value)
     | hb_map (hb_ridentity)
   )
 

--- a/src/java.desktop/share/native/libharfbuzz/hb-subset.cc
+++ b/src/java.desktop/share/native/libharfbuzz/hb-subset.cc
@@ -43,11 +43,7 @@
 #include "OT/Color/sbix/sbix.hh"
 #include "hb-ot-os2-table.hh"
 #include "hb-ot-post-table.hh"
-
-#if !defined(AIX) || defined(AIX_XLC_GE_17)
 #include "hb-ot-post-table-v2subset.hh"
-#endif
-
 #include "hb-ot-cff1-table.hh"
 #include "hb-ot-cff2-table.hh"
 #include "hb-ot-vorg-table.hh"


### PR DESCRIPTION
This is a replay of https://github.com/ibmruntimes/openj9-openjdk-jdk17/pull/235 for Java 21, expanded for Harfbuzz 7.2.0.

Issue: https://github.com/eclipse-openj9/openj9/issues/17759.