### PR TITLE
Set a default thread name for java.util.TimerThread

### DIFF
--- a/src/java.base/share/classes/java/util/Timer.java
+++ b/src/java.base/share/classes/java/util/Timer.java
@@ -25,7 +25,7 @@
 
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2022, 2022 All Rights Reserved
+ * (c) Copyright IBM Corp. 2022, 2023 All Rights Reserved
  * ===========================================================================
  */
 
@@ -542,6 +542,7 @@ class TimerThread extends Thread {
     private TaskQueue queue;
 
     TimerThread(TaskQueue queue) {
+        super("java.util.TimerThread");
         this.queue = queue;
     }
 


### PR DESCRIPTION
Issue https://github.com/eclipse-openj9/openj9/issues/11930

The name isn't set in the TimerThread constructor, it calls Thread.genThreadName() which consumes the "Thread-0" name. This causes the test to fail because it expects this name. This could have an impact on / confuse users which expect consistent thread names. Depending on the timing of the Attach API AttachHandler / FilelockTimer creation, an application can get different default thread names from run to run.

Backport of https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/640