### PR TITLE
Update hb-map.hh

### DIFF
--- a/src/java.desktop/share/native/libharfbuzz/hb-map.hh
+++ b/src/java.desktop/share/native/libharfbuzz/hb-map.hh
@@ -347,8 +347,7 @@ struct hb_hashmap_t
   )
   auto keys () const HB_AUTO_RETURN
   (
-    + iter_items ()
-    | hb_map (&item_t::get_key)
+    + keys_ref ()
     | hb_map (hb_ridentity)
   )
   auto values_ref () const HB_AUTO_RETURN
@@ -358,8 +357,7 @@ struct hb_hashmap_t
   )
   auto values () const HB_AUTO_RETURN
   (
-    + iter_items ()
-    | hb_map (&item_t::get_value)
+    + values_ref ()
     | hb_map (hb_ridentity)
   )
 


### PR DESCRIPTION
Apply the fix for harfbuzz#4138 more directly. This is a back-port of https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/642.