### PR TITLE
Force global GC in ReferencedKeyTest

### DIFF
--- a/test/jdk/java/lang/runtime/ReferencedKeyTest.java
+++ b/test/jdk/java/lang/runtime/ReferencedKeyTest.java
@@ -88,6 +88,10 @@ public class ReferencedKeyTest {
 
     static void collect() {
         System.gc();
+        System.gc();
+        System.runFinalization();
+        System.gc();
+        System.gc();
         sleep();
     }
 


### PR DESCRIPTION
Fixes: https://github.com/eclipse-openj9/openj9/issues/17910