### PR TITLE
Ensure AttachAPI initialized  before starting attaching tests

### DIFF
--- a/test/jdk/com/sun/tools/attach/warnings/Application.java
+++ b/test/jdk/com/sun/tools/attach/warnings/Application.java
@@ -21,9 +21,17 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ */
+
 import java.io.DataOutputStream;
 import java.net.InetAddress;
 import java.net.Socket;
+
+import openj9.internal.tools.attach.target.AttachHandler;
 
 /**
  * The "application" launched by DyamicLoadWarningTest.
@@ -39,6 +47,10 @@ public class Application {
 
             // send pid
             long pid = ProcessHandle.current().pid();
+            while (!AttachHandler.isAttachApiInitialized()) {
+                // delay 2s to allow AttachAPI initialization
+                Thread.currentThread().sleep(100);
+            }
             out.writeLong(pid);
 
             // wait for shutdown

--- a/test/jdk/com/sun/tools/attach/warnings/DynamicLoadWarningTest.java
+++ b/test/jdk/com/sun/tools/attach/warnings/DynamicLoadWarningTest.java
@@ -22,13 +22,20 @@
  */
 
 /*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ */
+
+/*
  * @test
  * @bug 8307478
  * @summary Test that a warning is printed when an agent is dynamically loaded
  * @requires vm.jvmti
  * @modules jdk.attach jdk.jcmd
  * @library /test/lib /test/jdk
- * @build Application JavaAgent
+ * @build JavaAgent
+ * @compile --add-exports java.base/openj9.internal.tools.attach.target=ALL-UNNAMED Application.java
  * @run junit/othervm/native DynamicLoadWarningTest
  */
 
@@ -272,7 +279,8 @@ class DynamicLoadWarningTest {
 
                 // launch application with the given VM options, waiting for it to terminate
                 Stream<String> s1 = Stream.of(vmopts);
-                Stream<String> s2 = Stream.of("Application", Integer.toString(listener.getLocalPort()));
+                String addExports = "--add-exports=java.base/openj9.internal.tools.attach.target=ALL-UNNAMED";
+                Stream<String> s2 = Stream.of(addExports, "Application", Integer.toString(listener.getLocalPort()));
                 String[] opts = Stream.concat(s1, s2).toArray(String[]::new);
                 OutputAnalyzer outputAnalyzer = ProcessTools
                         .executeTestJava(opts)


### PR DESCRIPTION
Ensure `AttachAPI` initialized before starting attaching tests

Check `AttachHandler.isAttachApiInitialized()`, and delay to allow `AttachAPI` initialization if necessary. 

Passed the grinder - https://openj9-jenkins.osuosl.org/job/Grinder/2957/

Cherry-pick
* https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/673

closes https://github.com/eclipse-openj9/openj9/issues/18125

Signed-off-by: Jason Feng <fengj@ca.ibm.com>