### PR TITLE
[FFI/Jtreg_JDK21] Adjust the padding bytes of struct on AIX

### DIFF
--- a/test/jdk/java/foreign/nested/TestNested.java
+++ b/test/jdk/java/foreign/nested/TestNested.java
@@ -22,6 +22,12 @@
  */
 
 /*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ */
+
+/*
  * @test
  * @enablePreview
  * @library ../ /test/lib
@@ -175,10 +181,10 @@ public class TestNested extends NativeTestHelper {
     ).withName("S8");
     static final StructLayout S9 = MemoryLayout.structLayout(
             C_CHAR.withName("f0"),
-            MemoryLayout.paddingLayout(7),
+            MemoryLayout.paddingLayout(C_DOUBLE.byteAlignment() - 1),
             MemoryLayout.sequenceLayout(2, C_DOUBLE).withName("f1"),
             C_CHAR.withName("f2"),
-            MemoryLayout.paddingLayout(7),
+            MemoryLayout.paddingLayout(C_DOUBLE.byteAlignment() - 1),
             S8.withName("f3")
     ).withName("S9");
     static final UnionLayout U8 = MemoryLayout.unionLayout(


### PR DESCRIPTION
The changes reflect the actual padding bytes of
the failing test structs support double on AIX.

Related: #eclipse-openj9/openj9/issues/18287

Signed-off-by: ChengJin01 <jincheng@ca.ibm.com>