### PR TITLE
Reduce the number of park and unpark iterations in ParkALot

### DIFF
--- a/test/jdk/java/lang/Thread/virtual/stress/ParkALot.java
+++ b/test/jdk/java/lang/Thread/virtual/stress/ParkALot.java
@@ -20,12 +20,17 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ */
 
 /*
  * @test
  * @summary Stress test parking and unparking
  * @requires vm.debug != true
- * @run main/othervm ParkALot 500000
+ * @run main/othervm ParkALot 5000
  */
 
 /*


### PR DESCRIPTION
`ParkALot` launches a number of virtual threads and expects each thread
to `park` and `unpark` `500_000` times. The test takes a lot of time to
execute, leading to timeouts in Jenkins testing.

The number of `park` and `unpark` iterations is reduced to `5_000`, which is
sufficient to verify functional behaviour. Further, the reduced
iterations allow the test to pass in a reasonable time in Jenkins
testing.

`vm.debug` is set to `false` for OpenJ9. So, the `vm.debug=true` variant is
left unmodified.

Related: https://github.com/eclipse-openj9/openj9/issues/18444