### PR TITLE
Adjust ThreadListStackTracesTest for checkReentrantLock

### DIFF
--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/ThreadListStackTracesTest/ThreadListStackTracesTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/ThreadListStackTracesTest/ThreadListStackTracesTest.java
@@ -20,6 +20,11 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ */
 
 /**
  * @test
@@ -45,7 +50,15 @@ abstract class TestTask implements Runnable {
     }
 
     public void ensureReady(Thread vt, Thread.State expState) {
-        // wait while the thread is not ready or thread state is unexpected
+        /*
+         * Sleep for 1 second to allow the thread to reach the expected state.
+         * When the virtual thread is mounted, the virtual thread state,
+         * which is obtained from the carrier thread, can transition between
+         * WAITING and RUNNABLE before the virtual thread is parked on the
+         * lock.
+         */
+        sleep(1000);
+        // Wait while the thread is not ready or thread state is unexpected.
         while (!threadReady || (vt.getState() != expState)) {
             sleep(1);
         }
@@ -97,6 +110,10 @@ public class ThreadListStackTracesTest {
         String name = "ReentrantLockTestTask";
         TestTask task = new ReentrantLockTestTask();
         Thread vt = Thread.ofVirtual().name(name).start(task);
+        // Wait until vt is waiting to acquire the lock.
+        while (!reentrantLock.hasQueuedThread(vt)) {
+            TestTask.sleep(1);
+        }
         task.ensureReady(vt, expState);
         checkStates(vt, expState);
     }


### PR DESCRIPTION
Adjust ThreadListStackTracesTest for checkReentrantLock
to be ready when the virtual thread state is WAITING after
the reentrant lock parks the virtual thread. When the
virtual thread is mounted, the virtual thread state, which
is obtained from the carrier thread, can transition
between WAITING and RUNNABLE before the virtual thread is
parked on the lock.

Issue: https://github.com/eclipse-openj9/openj9/issues/18089
Signed-off-by: Amarpreet Singh <Amarpreet.A.Singh@ibm.com>