### PR TITLE
CRIU adds @NotCheckpointSafe for PrintStream.writeln(String)

### DIFF
--- a/src/java.base/share/classes/java/io/PrintStream.java
+++ b/src/java.base/share/classes/java/io/PrintStream.java
@@ -23,6 +23,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ */
+
 package java.io;
 
 import java.util.Formatter;
@@ -33,6 +39,10 @@ import java.nio.charset.UnsupportedCharsetException;
 import jdk.internal.access.JavaIOPrintStreamAccess;
 import jdk.internal.access.SharedSecrets;
 import jdk.internal.misc.InternalLock;
+
+/*[IF CRIU_SUPPORT]*/
+import openj9.internal.criu.NotCheckpointSafe;
+/*[ENDIF] CRIU_SUPPORT */
 
 /**
  * A {@code PrintStream} adds functionality to another output stream,
@@ -818,6 +828,9 @@ public class PrintStream extends FilterOutputStream
     // using println, but since subclasses could exist which depend on
     // observing a call to print followed by newLine we only use this if
     // getClass() == PrintStream.class to avoid compatibility issues.
+    /*[IF CRIU_SUPPORT]*/
+    @NotCheckpointSafe
+    /*[ENDIF] CRIU_SUPPORT */
     private void writeln(String s) {
         try {
             if (lock != null) {


### PR DESCRIPTION
`CRIU` adds `@NotCheckpointSafe` for `PrintStream.writeln(String)`

Cherry-pick 
* https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/694

close https://github.com/eclipse-openj9/openj9/issues/18471

Signed-off-by: Jason Feng <fengj@ca.ibm.com>