### PR TITLE
Cherry pick exclude fips for jdk21

### DIFF
--- a/src/java.base/unix/classes/sun/security/provider/NativePRNG.java
+++ b/src/java.base/unix/classes/sun/security/provider/NativePRNG.java
@@ -25,7 +25,7 @@
 
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2022, 2023 All Rights Reserved
+ * (c) Copyright IBM Corp. 2022, 2024 All Rights Reserved
  * ===========================================================================
  */
 
@@ -508,8 +508,9 @@ public final class NativePRNG extends SecureRandomSpi {
                 if (in.readNBytes(data, 0, len) < len) {
                     throw new IOException("Could not read from file(s)");
                 }
+                return;
             }
-            /*[ELSE] CRIU_SUPPORT */
+            /*[ENDIF] CRIU_SUPPORT */
             int ofs = 0;
             while (len > 0) {
                 int k = in.read(data, ofs, len);
@@ -522,7 +523,6 @@ public final class NativePRNG extends SecureRandomSpi {
             if (len > 0) {
                 throw new IOException("Could not read from file(s)");
             }
-            /*[ENDIF] CRIU_SUPPORT */
         }
 
         // get true random bytes, just read from "seed"
@@ -634,8 +634,9 @@ public final class NativePRNG extends SecureRandomSpi {
                         for (int i = 0; i < data.length; i++) {
                             data[i] ^= rawData[i];
                         }
+                        return;
                     }
-                    /*[ELSE] CRIU_SUPPORT */
+                    /*[ENDIF] CRIU_SUPPORT */
                     int data_len = data.length;
                     int ofs = 0;
                     int len;
@@ -665,7 +666,6 @@ public final class NativePRNG extends SecureRandomSpi {
                         }
                     data_len -= len;
                     }
-                    /*[ENDIF] CRIU_SUPPORT */
                 } catch (IOException e){
                     throw new ProviderException("nextBytes() failed", e);
                 }

--- a/test/jdk/ProblemList-FIPS140_2.txt
+++ b/test/jdk/ProblemList-FIPS140_2.txt
@@ -1229,3 +1229,7 @@ javax/smartcardio/TerminalFactorySpiTest.java https://github.ibm.com/runtimes/ba
 java/util/jar/JarFile/SignedJarPendingBlock.java https://github.ibm.com/runtimes/backlog/issues/1089 linux-x64,linux-ppc64le,linux-s390x
 sun/security/krb5/auto/Unavailable.java https://github.ibm.com/runtimes/backlog/issues/1089 linux-x64,linux-ppc64le,linux-s390x
 sun/security/krb5/etype/WeakCrypto.java https://github.ibm.com/runtimes/backlog/issues/1089 linux-x64,linux-ppc64le,linux-s390x
+java/foreign/TestFallbackLookup.java    https://github.ibm.com/runtimes/backlog/issues/1291 linux-ppc64le,linux-s390x
+sun/security/krb5/auto/Cleaners.java    https://github.ibm.com/runtimes/backlog/issues/1089 linux-x64,linux-ppc64le,linux-s390x
+sun/security/krb5/auto/S4U2selfNotF.java    https://github.ibm.com/runtimes/backlog/issues/1089 linux-x64,linux-ppc64le,linux-s390x
+java/util/jar/JarFile/IgnoreUnrelatedSignatureFiles.java    https://github.ibm.com/runtimes/backlog/issues/1089 linux-x64,linux-ppc64le,linux-s390x


### PR DESCRIPTION
Exclude subtests for FIPS openjdk21_j9
    -Exclude `java/foreign/TestFallbackLookup.java`
    -Exclude  `java/util/jar/JarFile/IgnoreUnrelatedSignatureFiles.java`
    -Exlcude `sun/security/krb5/auto/S4U2selfNotF.java`
    -Exclude `sun/security/krb5/auto/Cleaners.java`

    related: backlog/issues/1089
    related: backlog/issues/1291