### PR TITLE
Use correct JNI function to call ArrayList.add()

### DIFF
--- a/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/j2secmod.c
+++ b/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/j2secmod.c
@@ -23,6 +23,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2024, 2024 All Rights Reserved
+ * ===========================================================================
+ */
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -241,7 +247,7 @@ JNIEXPORT jobject JNICALL Java_sun_security_pkcs11_Secmod_nssGetModuleList
             if (jModule == NULL) {
                 return NULL;
             }
-            (*env)->CallVoidMethod(env, jList, jAdd, jModule);
+            (*env)->CallBooleanMethod(env, jList, jAdd, jModule);
             if ((*env)->ExceptionCheck(env)) {
                 return NULL;
             }


### PR DESCRIPTION
Various testcases are being run as part of the `openj9` project. Currently one of these tests is failing since they are able to detect that the wrong method signature is being used by JNI calls at runtime.

This update makes the same method call only it expects a boolean to be returned from the method call. This allows for the test to pass the JNI method signature check.

This fixes [openj9 issue 17795](https://github.com/eclipse-openj9/openj9/issues/17795).