### PR TITLE
Use the regular release branches for openj9 & omr for CE releases

### DIFF
--- a/closed/get_j9_source.sh
+++ b/closed/get_j9_source.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # ===========================================================================
-# (c) Copyright IBM Corp. 2017, 2023 All Rights Reserved
+# (c) Copyright IBM Corp. 2017, 2024 All Rights Reserved
 # ===========================================================================
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -67,9 +67,9 @@ git_urls[openj9]=https://github.com/eclipse-openj9/openj9
 git_urls[omr]=https://github.com/eclipse-openj9/openj9-omr
 
 currentbranch=$(git rev-parse --abbrev-ref HEAD)
-if [[ "$currentbranch" =~ v[0-9]+\.[0-9]+(\.[0-9]+)?-release ]] ; then
-	branches[openj9]=$currentbranch
-	branches[omr]=$currentbranch
+if [[ "$currentbranch" =~ (ibm-)?v[0-9]+\.[0-9]+(\.[0-9]+)?-release ]] ; then
+	branches[openj9]=${currentbranch#ibm-}
+	branches[omr]=${currentbranch#ibm-}
 else
 	branches[openj9]=master
 	branches[omr]=openj9


### PR DESCRIPTION
CE extensions release branches are prefixed with 'ibm-'. We can remove this prefix to checkout the correct openj9/omr release branches