### PR TITLE
Initialize VarHandle.methodHandleTable and its entries with atomic CAS

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/VarHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/VarHandle.java
@@ -23,6 +23,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2024, 2024 All Rights Reserved
+ * ===========================================================================
+ */
+
 package java.lang.invoke;
 
 import java.lang.constant.ClassDesc;
@@ -35,6 +41,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
+import jdk.internal.misc.Unsafe;
 import jdk.internal.vm.annotation.DontInline;
 import jdk.internal.vm.annotation.ForceInline;
 import jdk.internal.vm.annotation.IntrinsicCandidate;
@@ -2173,15 +2180,32 @@ public abstract sealed class VarHandle implements Constable
     @Stable
     MethodHandle[] methodHandleTable;
 
+    private static final long METHOD_HANDLE_TABLE_OFFSET;
+
+    static {
+        METHOD_HANDLE_TABLE_OFFSET = UNSAFE.objectFieldOffset(VarHandle.class, "methodHandleTable");
+    }
+
     @ForceInline
     final MethodHandle getMethodHandle(int mode) {
         MethodHandle[] mhTable = methodHandleTable;
         if (mhTable == null) {
-            mhTable = methodHandleTable = new MethodHandle[AccessMode.COUNT];
+            mhTable = new MethodHandle[AccessMode.COUNT];
+            Object other = UNSAFE.compareAndExchangeReference(this, METHOD_HANDLE_TABLE_OFFSET, null, mhTable);
+            if (other != null) {
+                // We lost the race. Use the winning table instead.
+                mhTable = (MethodHandle[])other;
+            }
         }
         MethodHandle mh = mhTable[mode];
         if (mh == null) {
-            mh = mhTable[mode] = getMethodHandleUncached(mode);
+            mh = getMethodHandleUncached(mode);
+            long offset = Unsafe.ARRAY_OBJECT_BASE_OFFSET + (Unsafe.ARRAY_OBJECT_INDEX_SCALE * mode);
+            Object other = UNSAFE.compareAndExchangeReference(mhTable, offset, null, mh);
+            if (other != null) {
+                // We lost the race. Use the winning handle instead.
+                mh = (MethodHandle)other;
+            }
         }
         return mh;
     }


### PR DESCRIPTION
This prevents double initialization when multiple threads are racing through `getMethodHandle()`. Once a non-null reference has been written to one of these locations, any subsequent write to the same location is a problem for the OpenJ9 JIT given its current handling of known objects.

This is the same patch as https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/747 and https://github.com/ibmruntimes/openj9-openjdk-jdk22/pull/28

Issue: https://github.com/eclipse-openj9/openj9/issues/18882