### PR TITLE
Add MemberName finalizer to mark clazz for MemberName list pruning

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/MemberName.java
+++ b/src/java.base/share/classes/java/lang/invoke/MemberName.java
@@ -23,6 +23,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2024, 2024 All Rights Reserved
+ * ===========================================================================
+ */
+
 package java.lang.invoke;
 
 import sun.invoke.util.VerifyAccess;
@@ -1007,6 +1013,13 @@ final class MemberName implements Member, Cloneable {
             if (result != null && result.isResolved())
                 return result;
             return null;
+        }
+    }
+
+    @Override
+    protected void finalize() {
+        if (null != clazz) {
+            MethodHandleNatives.markClassForMemberNamePruning(clazz);
         }
     }
 }

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandleNatives.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandleNatives.java
@@ -23,6 +23,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2024, 2024 All Rights Reserved
+ * ===========================================================================
+ */
+
 package java.lang.invoke;
 
 import jdk.internal.misc.VM;
@@ -689,4 +695,9 @@ class MethodHandleNatives {
         return (definingClass.isAssignableFrom(symbolicRefClass) ||  // Msym overrides Mdef
                 symbolicRefClass.isInterface());                     // Mdef implements Msym
     }
+
+    /**
+     * Inform the VM that a MemberName belonging to class c has been collected.
+     */
+    static native void markClassForMemberNamePruning(Class<?> c);
 }


### PR DESCRIPTION
This prevents a memory leak in the maintenance of per-class lists used to find affected `MemberName` objects in case of class redefinition.

This is https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/759 for JDK21. Aside from line numbers, the diff is the same as in https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/759 and https://github.com/ibmruntimes/openj9-openjdk-jdk22/pull/35