### PR TITLE
Add support for native MD5 digest

### DIFF
--- a/closed/src/java.base/share/classes/jdk/crypto/jniprovider/NativeCrypto.java
+++ b/closed/src/java.base/share/classes/jdk/crypto/jniprovider/NativeCrypto.java
@@ -1,6 +1,6 @@
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2018, 2023 All Rights Reserved
+ * (c) Copyright IBM Corp. 2018, 2024 All Rights Reserved
  * ===========================================================================
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,6 +47,7 @@ public class NativeCrypto {
     public static final int SHA2_256 = 2;
     public static final int SHA5_384 = 3;
     public static final int SHA5_512 = 4;
+    public static final int MD5 = 5;
 
     /* Define constants for the EC field types. */
     public static final int ECField_Fp = 0;
@@ -200,6 +201,8 @@ public class NativeCrypto {
     /* Native digest interfaces */
 
     private static final native long loadCrypto(boolean trace);
+
+    public static final native boolean isMD5Available();
 
     public final native long DigestCreateContext(long nativeBuffer,
                                                  int algoIndex);

--- a/closed/src/java.base/share/classes/sun/security/provider/NativeMD5.java
+++ b/closed/src/java.base/share/classes/sun/security/provider/NativeMD5.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2003, 2014, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2024, 2024 All Rights Reserved
+ * ===========================================================================
+ */
+
+package sun.security.provider;
+
+import jdk.crypto.jniprovider.NativeCrypto;
+
+public final class NativeMD5 extends NativeDigest {
+
+    public NativeMD5() {
+        super("MD5", 16, NativeCrypto.MD5);
+    }
+}

--- a/closed/src/java.base/share/native/libjncrypto/NativeCrypto.c
+++ b/closed/src/java.base/share/native/libjncrypto/NativeCrypto.c
@@ -1,6 +1,6 @@
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2018, 2023 All Rights Reserved
+ * (c) Copyright IBM Corp. 2018, 2024 All Rights Reserved
  * ===========================================================================
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -200,6 +200,7 @@ static OSSL_CRYPTO_THREADID_set_callback_t* OSSL_CRYPTO_THREADID_set_callback = 
 static OSSL_CRYPTO_set_locking_callback_t* OSSL_CRYPTO_set_locking_callback = NULL;
 
 /* Define pointers for OpenSSL functions to handle Message Digest algorithms. */
+OSSL_sha_t* OSSL_md5;
 OSSL_sha_t* OSSL_sha1;
 OSSL_sha_t* OSSL_sha256;
 OSSL_sha_t* OSSL_sha224;
@@ -439,6 +440,7 @@ JNIEXPORT jlong JNICALL Java_jdk_crypto_jniprovider_NativeCrypto_loadCrypto
     }
 
     /* Load the function symbols for OpenSSL Message Digest algorithms. */
+    OSSL_md5 = (OSSL_sha_t*)find_crypto_symbol(crypto_library, "EVP_md5");
     OSSL_sha1 = (OSSL_sha_t*)find_crypto_symbol(crypto_library, "EVP_sha1");
     OSSL_sha256 = (OSSL_sha_t*)find_crypto_symbol(crypto_library, "EVP_sha256");
     OSSL_sha224 = (OSSL_sha_t*)find_crypto_symbol(crypto_library, "EVP_sha224");
@@ -855,6 +857,18 @@ JNIEXPORT void JNICALL JNI_OnUnload(JavaVM * vm, void * reserved)
     crypto_library = NULL;
 }
 
+/* Check whether MD5 is available.
+ *
+ * Class:     jdk_crypto_jniprovider_NativeCrypto
+ * Method:    isMD5Available
+ * Signature: ()Z
+ */
+JNIEXPORT jboolean JNICALL Java_jdk_crypto_jniprovider_NativeCrypto_isMD5Available
+  (JNIEnv *env, jclass thisClass)
+{
+    return (NULL != OSSL_md5) ? JNI_TRUE : JNI_FALSE;
+}
+
 /* Create Digest context
  *
  * Class:     jdk_crypto_jniprovider_NativeCrypto
@@ -869,6 +883,9 @@ JNIEXPORT jlong JNICALL Java_jdk_crypto_jniprovider_NativeCrypto_DigestCreateCon
     OpenSSLMDContext *context = NULL;
 
     switch (algoIdx) {
+        case jdk_crypto_jniprovider_NativeCrypto_MD5:
+            digestAlg = (*OSSL_md5)();
+            break;
         case jdk_crypto_jniprovider_NativeCrypto_SHA1_160:
             digestAlg = (*OSSL_sha1)();
             break;


### PR DESCRIPTION
A new class, namely `NativeMD5.java`, is created and the corresponding options are added in other places to allow for the use of native `OpenSSL` library to perform `MD5` digests.

Back-ported from: https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/765

Signed-off by: Kostas Tsiounis [kostas.tsiounis@ibm.com](mailto:kostas.tsiounis@ibm.com)