### PR TITLE
Detect operating systems consistently in SystemLookup

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/SystemLookup.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/SystemLookup.java
@@ -70,7 +70,7 @@ public final class SystemLookup implements SymbolLookup {
 
     private static SymbolLookup makeSystemLookup() {
         try {
-            if (Utils.IS_WINDOWS) {
+            if (OperatingSystem.isWindows()) {
                 return makeWindowsLookup();
             } else if (OperatingSystem.isAix() || OperatingSystem.isZOS()) {
                 return makeDefaultLookup();
@@ -193,7 +193,7 @@ public final class SystemLookup implements SymbolLookup {
      */
     private static Path jdkLibraryPath(String name) {
         Path javahome = Path.of(GetPropertyAction.privilegedGetProperty("java.home"));
-        String lib = Utils.IS_WINDOWS ? "bin" : "lib";
+        String lib = OperatingSystem.isWindows() ? "bin" : "lib";
         String libname = System.mapLibraryName(name);
         return javahome.resolve(lib).resolve(libname);
     }


### PR DESCRIPTION
Mixing uses of `Utils.IS_WINDOWS` with `OperatingSystem.isXXX()` lead to use of a Windows-specific path for AIX (and z/OS) causing a failure to find the `syslookup` library.

Issue: [openj9#19573](https://github.com/eclipse-openj9/openj9/issues/19573).