### PR TITLE
Acquire interruptLock for interruptImpl and isInterruptedImpl

### DIFF
--- a/src/java.base/share/classes/java/lang/Thread.java
+++ b/src/java.base/share/classes/java/lang/Thread.java
@@ -25,7 +25,7 @@
 
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2021, 2023 All Rights Reserved
+ * (c) Copyright IBM Corp. 2021, 2024 All Rights Reserved
  * ===========================================================================
  */
 
@@ -1774,7 +1774,9 @@ public class Thread implements Runnable {
     public boolean isInterrupted() {
         // use fully qualified name to avoid ambiguous class error
         if (com.ibm.oti.vm.VM.isJVMInSingleThreadedMode()) {
-            return isInterruptedImpl();
+            synchronized (interruptLock) {
+                return isInterruptedImpl();
+            }
         }
         return interrupted;
     }
@@ -3031,7 +3033,9 @@ public class Thread implements Runnable {
     }
 
     private void interrupt0() {
-        interruptImpl();
+        synchronized (interruptLock) {
+            interruptImpl();
+        }
     }
 
     private static void clearInterruptEvent() {


### PR DESCRIPTION
`interruptImpl` and `isInterruptedImpl` use the `eetop/threadRef` value.
Acquiring `interruptLock` assures that the `eetop/threadRef` value won't
change during `interruptImpl` and `isInterruptedImpl`. This will prevent
crashes which happen when a stale `eetop/threadRef` value is used to
invoke OMR thread library functions.

Related: https://github.com/eclipse-openj9/openj9/issues/19544
Related: https://github.com/eclipse-openj9/openj9/issues/19598

Backport of https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/803