### PR TITLE
Disable DTLSv1.0 protocol in FIPS140-3 strict

### DIFF
--- a/src/java.base/share/conf/security/java.security
+++ b/src/java.base/share/conf/security/java.security
@@ -185,7 +185,7 @@ RestrictedSecurity.NSS.140-2.securerandom.algorithm = PKCS11
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.desc.name = OpenJCEPlusFIPS Cryptographic Module FIPS 140-3
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.desc.default = false
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.desc.fips = true
-RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.desc.hash = SHA256:dd19c8f8f2578cf400c11b5c7d003684cba5fc4999ac5c55d2a73099f70f9582
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.desc.hash = SHA256:4a85dc0db2f257388155b3ada7378773884edc89c80c8d715f4bdde84cc3d8bd
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.desc.number = Certificate #XXX
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.desc.policy = https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.desc.sunsetDate = 2026-09-21
@@ -197,6 +197,7 @@ RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.tls.disabledAlgorithms = \
     anon, \
     DES, \
     DH keySize < 2048, \
+    DTLSv1.0, \
     EC keySize < 224, \
     ECDH, \
     MD5withRSA, \


### PR DESCRIPTION
FIPS140-3 strict profile overrides the tls.disabledAlgorithm list. But DTLSv1.0 is missing in the that list. Need to add it back.