### PR TITLE
Remove unused variables in NativeCrypto.c

### DIFF
--- a/closed/src/java.base/share/native/libjncrypto/NativeCrypto.c
+++ b/closed/src/java.base/share/native/libjncrypto/NativeCrypto.c
@@ -373,7 +373,6 @@ static void *crypto_library = NULL;
 JNIEXPORT jlong JNICALL Java_jdk_crypto_jniprovider_NativeCrypto_loadCrypto
   (JNIEnv *env, jclass thisObj, jboolean trace)
 {
-    char *error;
     typedef const char* OSSL_version_t(int);
 
     /* Determine the version of OpenSSL. */
@@ -2303,7 +2302,6 @@ JNIEXPORT jint JNICALL Java_jdk_crypto_jniprovider_NativeCrypto_ChaCha20FinalEnc
   (JNIEnv *env, jobject thisObj, jlong c, jbyteArray output, jint outputOffset, jint tagLen)
 {
     int len = 0;
-    int outputLen = -1;
     unsigned char *outputNative = NULL;
     EVP_CIPHER_CTX *ctx = (EVP_CIPHER_CTX*)(intptr_t) c;
 
@@ -2346,7 +2344,6 @@ JNIEXPORT jint JNICALL Java_jdk_crypto_jniprovider_NativeCrypto_ChaCha20FinalDec
 {
     int len = 0;
     int plaintext_len = 0;
-    int outputLen = 0;
     int ret = 0;
 
     unsigned char *inputNative = NULL;
@@ -2839,10 +2836,6 @@ Java_jdk_crypto_jniprovider_NativeCrypto_ECEncodeGF
     BIGNUM *yBN = NULL;
     BIGNUM *nBN = NULL;
     BIGNUM *hBN = NULL;
-    EC_GROUP *group = NULL;
-    EC_POINT *generator = NULL;
-    BN_CTX *ctx = NULL;
-    int ret = 0;
 
     nativeA = (unsigned char *)((*env)->GetPrimitiveArrayCritical(env, a, 0));
     if (NULL == nativeA) {


### PR DESCRIPTION
There are a few variables in the native code contained in the `NativeCrypto.c` file that are unused and can be removed.

Back-ported from: https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/834

Signed-off-by: Kostas Tsiounis <kostas.tsiounis@ibm.com>