### PR TITLE
Add DebugOptions test into OpenJCEPlusFIPS ProblemList

### DIFF
--- a/test/jdk/ProblemList-FIPS140_3_OpenJcePlus.txt
+++ b/test/jdk/ProblemList-FIPS140_3_OpenJcePlus.txt
@@ -932,6 +932,7 @@ sun/security/tools/keytool/fakecacerts/TrustedCRL.java https://github.com/ibmrun
 sun/security/tools/keytool/fakecacerts/TrustedCert.java https://github.com/ibmruntimes/openj9-openjdk-jdk21/issues/153 aix-all,linux-ppc64le,linux-s390x,linux-x64
 sun/security/tools/keytool/fakegen/DefaultSignatureAlgorithm.java https://github.com/ibmruntimes/openj9-openjdk-jdk21/issues/153 aix-all,linux-ppc64le,linux-s390x,linux-x64
 sun/security/tools/keytool/fakegen/PSS.java https://github.com/ibmruntimes/openj9-openjdk-jdk21/issues/153 aix-all,linux-ppc64le,linux-s390x,linux-x64
+sun/security/util/Debug/DebugOptions.java https://github.com/eclipse-openj9/openj9/issues/19977 aix-all,linux-ppc64le,linux-s390x,linux-x64,windows-all
 sun/security/util/HostnameChecker/NullHostnameCheck.java https://github.com/ibmruntimes/openj9-openjdk-jdk21/issues/153 aix-all,linux-ppc64le,linux-s390x,linux-x64
 sun/security/util/InternalPrivateKey/Correctness.java https://github.com/ibmruntimes/openj9-openjdk-jdk21/issues/153 aix-all,linux-ppc64le,linux-s390x,linux-x64
 sun/security/validator/EndEntityExtensionCheck.java https://github.com/ibmruntimes/openj9-openjdk-jdk21/issues/153 aix-all,linux-ppc64le,linux-s390x,linux-x64


### PR DESCRIPTION
This PR is for updating the OpenJCEPlusFIPS ignore list to exclude the `sun/security/util/Debug/DebugOptions.java` test, which is not designed for testing the security properties output for OpenJCEPlusFIPS profile.