### PR TITLE
keep Runnable r strongly reachable so that it is not reclaimable by GC

### DIFF
--- a/test/jdk/java/lang/ClassLoader/nativeLibrary/NativeLibraryTest.java
+++ b/test/jdk/java/lang/ClassLoader/nativeLibrary/NativeLibraryTest.java
@@ -97,6 +97,8 @@ public class NativeLibraryTest {
             throw new RuntimeException("should fail to load the native library" +
                     " by another class loader");
         } catch (UnsatisfiedLinkError e) {}
+        // keep Runnable r strongly reachable so that it is not reclaimable by GC
+        java.lang.ref.Reference.reachabilityFence(r);
     }
 
     /*


### PR DESCRIPTION
keep `Runnable r` strongly reachable so that it is not reclaimable by GC

The GC might occur before the second native library loading by another class loader, keep `Runnable r` strongly reachable so that it is not reclaimable by `GC`, and ensure `UnsatisfiedLinkError`.

Cherry-pick
* https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/851

Signed-off-by: Jason Feng <fengj@ca.ibm.com>