### PR TITLE
Select the appropriate OpenSSL build target on AIX

### DIFF
--- a/closed/openssl.gmk
+++ b/closed/openssl.gmk
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2018, 2023 All Rights Reserved
+# (c) Copyright IBM Corp. 2018, 2024 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -25,6 +25,7 @@ ifeq (,$(wildcard $(SPEC)))
 endif
 
 include $(SPEC)
+include MakeBase.gmk
 
 ifeq ($(OPENJDK_TARGET_OS), windows)
   # Configure normally demands that we use an implementation of perl that produces
@@ -63,7 +64,11 @@ endif # windows
 # Identify the desired openssl target configuration.
 OPENSSL_TARGET :=
 ifeq ($(OPENJDK_TARGET_OS), aix)
-  OPENSSL_TARGET := aix64-cc
+  ifeq ($(call isCompiler, clang), true)
+    OPENSSL_TARGET := aix64-clang
+  else ifeq ($(call isCompiler, xlc), true)
+    OPENSSL_TARGET := aix64-cc
+  endif
 else ifeq ($(OPENJDK_TARGET_OS), linux)
   ifneq (,$(filter aarch64 ppc64le x86_64, $(OPENJDK_TARGET_CPU)))
     OPENSSL_TARGET := linux-$(OPENJDK_TARGET_CPU)


### PR DESCRIPTION
This is a back-port of https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/853.