### PR TITLE
JFR copy $(OPENJ9_TOPDIR)/runtime/metadata.blob to $(LIB_DST_DIR)

### DIFF
--- a/closed/custom/modules/java.base/Copy.gmk
+++ b/closed/custom/modules/java.base/Copy.gmk
@@ -186,6 +186,14 @@ $(call openj9_copy_files,, \
 
 endif # OPENJ9_ENABLE_DDR
 
+ifeq (true,$(OPENJ9_ENABLE_JFR))
+
+$(call openj9_copy_files,, \
+	$(OPENJ9_TOPDIR)/runtime/metadata.blob \
+	$(LIB_DST_DIR)/metadata.blob)
+
+endif # OPENJ9_ENABLE_JFR
+
 ##########################################################################################
 # Optionally copy OpenSSL Crypto Library
 # To bundle first search for openssl 1.1.x library, if not found, search for 1.0.x


### PR DESCRIPTION
JFR copy `$(OPENJ9_TOPDIR)/runtime/metadata.blob` to `$(LIB_DST_DIR)`

Cherry-pick
* https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/863

Depends on
* https://github.com/eclipse-openj9/openj9/pull/20358

Signed-off-by: Jason Feng <fengj@ca.ibm.com>