### PR TITLE
Reduce lock contention in Thread.getAndClearInterrupt

### DIFF
--- a/src/java.base/share/classes/java/lang/Thread.java
+++ b/src/java.base/share/classes/java/lang/Thread.java
@@ -1805,14 +1805,17 @@ public class Thread implements Runnable {
         if (com.ibm.oti.vm.VM.isJVMInSingleThreadedMode()) {
             return interruptedImpl();
         }
-        synchronized (interruptLock) {
-            boolean oldValue = interrupted;
-            if (oldValue) {
-                interrupted = false;
-                clearInterruptEvent();
+        boolean oldValue = interrupted;
+        if (oldValue) {
+            synchronized (interruptLock) {
+                oldValue = interrupted;
+                if (oldValue) {
+                    interrupted = false;
+                    clearInterruptEvent();
+                }
             }
-            return oldValue;
         }
+        return oldValue;
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/VirtualThread.java
+++ b/src/java.base/share/classes/java/lang/VirtualThread.java
@@ -24,7 +24,7 @@
  */
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2022, 2023 All Rights Reserved
+ * (c) Copyright IBM Corp. 2022, 2024 All Rights Reserved
  * ===========================================================================
  */
 package java.lang;
@@ -887,8 +887,11 @@ final class VirtualThread extends BaseVirtualThread {
         boolean oldValue = interrupted;
         if (oldValue) {
             synchronized (interruptLock) {
-                interrupted = false;
-                carrierThread.clearInterrupt();
+                oldValue = interrupted;
+                if (oldValue) {
+                    interrupted = false;
+                    carrierThread.clearInterrupt();
+                }
             }
         }
         return oldValue;


### PR DESCRIPTION
Lock contention in `Thread.getAndClearInterrupt` is reduced by
acquiring the lock only when the value of the `Thread.interrupted`
field is `true`.

Related: https://github.com/eclipse-openj9/openj9/issues/20414