### PR TITLE
Fix names of algorithms printed in debug trace

### DIFF
--- a/src/jdk.crypto.ec/share/classes/sun/security/ec/SunEC.java
+++ b/src/jdk.crypto.ec/share/classes/sun/security/ec/SunEC.java
@@ -67,30 +67,30 @@ public final class SunEC extends Provider {
     /* The property 'jdk.nativeEC' is used to control enablement of the native
      * ECDH implementation.
      */
-    private static final boolean useNativeECDH = NativeCrypto.isAlgorithmEnabled("jdk.nativeEC", "SunEC");
+    private static final boolean useNativeECDH = NativeCrypto.isAlgorithmEnabled("jdk.nativeEC", "ECDH");
 
     /* The property 'jdk.nativeECKeyGen' is used to control enablement of the native
      * ECKeyGeneration implementation.
      * OpenSSL 1.1.0 or above is required for EC key generation support.
      */
-    private static final boolean useNativeECKeyGen = NativeCrypto.isAlgorithmEnabled("jdk.nativeECKeyGen", "SunEC");
+    private static final boolean useNativeECKeyGen = NativeCrypto.isAlgorithmEnabled("jdk.nativeECKeyGen", "ECKeyGen");
 
     /* The property 'jdk.nativeECDSA' is used to control enablement of the native
      * ECDSA signature implementation.
      */
-    private static final boolean useNativeECDSA = NativeCrypto.isAlgorithmEnabled("jdk.nativeECDSA", "SunEC");
+    private static final boolean useNativeECDSA = NativeCrypto.isAlgorithmEnabled("jdk.nativeECDSA", "ECDSA");
 
     /* The property 'jdk.nativeXDHKeyAgreement' is used to control enablement of the native
      * XDH key agreement. XDH key agreement is only supported in OpenSSL 1.1.1 and above.
      */
     private static final boolean useNativeXDHKeyAgreement =
-        NativeCrypto.isAlgorithmEnabled("jdk.nativeXDHKeyAgreement", "SunEC");
+        NativeCrypto.isAlgorithmEnabled("jdk.nativeXDHKeyAgreement", "XDHKeyAgreement");
 
     /* The property 'jdk.nativeXDHKeyGen' is used to control enablement of the native
      * XDH key generation. XDH key generation is only supported in OpenSSL 1.1.1 and above.
      */
     private static final boolean useNativeXDHKeyGen =
-        NativeCrypto.isAlgorithmEnabled("jdk.nativeXDHKeyGen", "SunEC");
+        NativeCrypto.isAlgorithmEnabled("jdk.nativeXDHKeyGen", "XDHKeyGen");
 
     private static class ProviderServiceA extends ProviderService {
         ProviderServiceA(Provider p, String type, String algo, String cn,


### PR DESCRIPTION
The parameter used to indicate the name of the algorithm, whose native implementation's availability is being checked, was incorrectly set to the provider name, leading to incorrect debug trace messages.

Back-ported from: https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/874

Signed-off-by: Kostas Tsiounis <kostas.tsiounis@ibm.com>