### PR TITLE
Add Xdump to diagnose intermittent JSR166TestCase failures

### DIFF
--- a/test/jdk/java/util/concurrent/tck/JSR166TestCase.java
+++ b/test/jdk/java/util/concurrent/tck/JSR166TestCase.java
@@ -39,7 +39,7 @@
  * @summary Conformance testing variant of JSR-166 tck tests.
  * @build *
  * @modules java.management
- * @run junit/othervm/timeout=1000 JSR166TestCase
+ * @run junit/othervm/timeout=1000 -Xdump:system+java+snap:events=systhrow,filter=java/lang/Exception,msg_filter=*JUnit* JSR166TestCase
  */
 
 /*
@@ -48,7 +48,7 @@
  *          with java security manager set to allow.
  * @build *
  * @modules java.management
- * @run junit/othervm/timeout=1000 -Djava.security.manager=allow JSR166TestCase
+ * @run junit/othervm/timeout=1000 -Djava.security.manager=allow -Xdump:system+java+snap:events=systhrow,filter=java/lang/Exception,msg_filter=*JUnit* JSR166TestCase
  */
 
 /*
@@ -62,6 +62,7 @@
  *      --add-opens java.base/java.lang=ALL-UNNAMED
  *      -Djsr166.testImplementationDetails=true
  *      -Djava.util.concurrent.ForkJoinPool.common.parallelism=0
+ *      -Xdump:system+java+snap:events=systhrow,filter=java/lang/Exception,msg_filter=*JUnit*
  *      JSR166TestCase
  * @run junit/othervm/timeout=1000
  *      --add-opens java.base/java.util.concurrent=ALL-UNNAMED
@@ -69,6 +70,7 @@
  *      -Djsr166.testImplementationDetails=true
  *      -Djava.util.concurrent.ForkJoinPool.common.parallelism=1
  *      -Djava.util.secureRandomSeed=true
+ *      -Xdump:system+java+snap:events=systhrow,filter=java/lang/Exception,msg_filter=*JUnit*
  *      JSR166TestCase
  */
 
@@ -83,11 +85,13 @@
  *      --add-opens java.base/java.util.concurrent=ALL-UNNAMED
  *      --add-opens java.base/java.lang=ALL-UNNAMED
  *      -Djsr166.testImplementationDetails=true
+ *      -Xdump:system+java+snap:events=systhrow,filter=java/lang/Exception,msg_filter=*JUnit*
  *      JSR166TestCase
  * @run junit/othervm/timeout=1000/policy=tck.policy
  *      --add-opens java.base/java.util.concurrent=ALL-UNNAMED
  *      --add-opens java.base/java.lang=ALL-UNNAMED
  *      -Djsr166.testImplementationDetails=true
+ *      -Xdump:system+java+snap:events=systhrow,filter=java/lang/Exception,msg_filter=*JUnit*
  *      JSR166TestCase
  */
 


### PR DESCRIPTION
Ported from https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/881

fyi @pshipton 