### PR TITLE
CRIU adds @NotCheckpointSafe for MethodAccessorGenerator.generateName()

### DIFF
--- a/closed/GensrcJ9JCL.gmk
+++ b/closed/GensrcJ9JCL.gmk
@@ -51,6 +51,7 @@ $(eval $(call SetupCopyFiles,COPY_OVERLAY_FILES, \
 		src/java.base/share/classes/java/util/zip/ZipFile.java \
 		src/java.base/share/classes/jdk/internal/access/JavaNetInetAddressAccess.java \
 		src/java.base/share/classes/jdk/internal/ref/PhantomCleanable.java \
+		src/java.base/share/classes/jdk/internal/reflect/MethodAccessorGenerator.java \
 		src/java.base/share/classes/module-info.java \
 		src/java.base/share/classes/sun/security/jca/ProviderConfig.java \
 		src/java.base/share/classes/sun/security/jca/ProviderList.java \

--- a/src/java.base/share/classes/jdk/internal/reflect/MethodAccessorGenerator.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/MethodAccessorGenerator.java
@@ -23,10 +23,20 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2024, 2024 All Rights Reserved
+ * ===========================================================================
+ */
+
 package jdk.internal.reflect;
 
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+
+/*[IF CRIU_SUPPORT]*/
+import openj9.internal.criu.NotCheckpointSafe;
+/*[ENDIF] CRIU_SUPPORT */
 
 /** Generator for jdk.internal.reflect.MethodAccessor and
     jdk.internal.reflect.ConstructorAccessor objects using bytecodes to
@@ -741,6 +751,9 @@ class MethodAccessorGenerator extends AccessorGenerator {
         return sb.toString();
     }
 
+    /*[IF CRIU_SUPPORT]*/
+    @NotCheckpointSafe
+    /*[ENDIF] CRIU_SUPPORT */
     private static synchronized String generateName(boolean isConstructor,
                                                     boolean forSerialization)
     {


### PR DESCRIPTION
CRIU adds `@NotCheckpointSafe` for `MethodAccessorGenerator.generateName()`

This is expected to address 

```
3XMTHREADINFO3           Java callstack:
4XESTACKTRACE                at jdk/internal/reflect/MethodAccessorGenerator.generate(MethodAccessorGenerator.java:287)
4XESTACKTRACE                at jdk/internal/reflect/MethodAccessorGenerator.generateMethod(MethodAccessorGenerator.java:75)
4XESTACKTRACE                at jdk/internal/reflect/NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:63(Compiled Code))
4XESTACKTRACE                at jdk/internal/reflect/DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43(Compiled Code))
4XESTACKTRACE                at java/lang/reflect/Method.invoke(Method.java:574(Compiled Code))
4XESTACKTRACE                at org/eclipse/openj9/criu/CRIUSupport.lambda$registerRestoreEnvVariables$4(CRIUSupport.java:732)
4XESTACKTRACE                at org/eclipse/openj9/criu/CRIUSupport$$Lambda$294/0x0000000000000000.run(Bytecode PC:4)
4XESTACKTRACE                at org/eclipse/openj9/criu/J9InternalCheckpointHookAPI$J9InternalCheckpointHook.runHook(J9InternalCheckpointHookAPI.java:143)
4XESTACKTRACE                at org/eclipse/openj9/criu/J9InternalCheckpointHookAPI.runHooks(J9InternalCheckpointHookAPI.java:98)
4XESTACKTRACE                at org/eclipse/openj9/criu/J9InternalCheckpointHookAPI.runPostRestoreHooksSingleThread(J9InternalCheckpointHookAPI.java:115)
4XESTACKTRACE                at org/eclipse/openj9/criu/CRIUSupport.checkpointJVMImpl(Native Method)
4XESTACKTRACE                at org/eclipse/openj9/criu/CRIUSupport.checkpointJVM(CRIUSupport.java:823)
4XESTACKTRACE                at io/openliberty/checkpoint/internal/openj9/ExecuteCRIU_OpenJ9.dump(ExecuteCRIU_OpenJ9.java:55)
4XESTACKTRACE                at io/openliberty/checkpoint/internal/CheckpointImpl.checkpoint(CheckpointImpl.java:396)
4XESTACKTRACE                at io/openliberty/checkpoint/internal/CheckpointImpl.checkpointOrExitOnFailure(CheckpointImpl.java:303)
4XESTACKTRACE                at io/openliberty/checkpoint/internal/CheckpointImpl.check(CheckpointImpl.java:297)
4XESTACKTRACE                at com/ibm/ws/kernel/feature/internal/FeatureManager$$Lambda$269/0x0000000000000000.accept(Bytecode PC:6)
4XESTACKTRACE                at java/util/ArrayList.forEach(ArrayList.java:1511)
4XESTACKTRACE                at com/ibm/ws/kernel/feature/internal/FeatureManager.checkServerReady(FeatureManager.java:868)
4XESTACKTRACE                at com/ibm/ws/kernel/feature/internal/FeatureManager.update(FeatureManager.java:829)
4XESTACKTRACE                at com/ibm/ws/kernel/feature/internal/FeatureManager.processFeatureChanges(FeatureManager.java:931)
4XESTACKTRACE                at com/ibm/ws/kernel/feature/internal/FeatureManager$1.run(FeatureManager.java:714)
4XESTACKTRACE                at com/ibm/ws/threading/internal/ExecutorServiceImpl$RunnableWrapper.run(ExecutorServiceImpl.java:298)
4XESTACKTRACE                at java/util/concurrent/ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136(Compiled Code))
4XESTACKTRACE                at java/util/concurrent/ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
4XESTACKTRACE                at java/lang/Thread.run(Thread.java:857)
```

`jdk/internal/reflect/MethodAccessorGenerator` only presents in JDK 21/17/11/8.


Signed-off-by: Jason Feng <fengj@ca.ibm.com>