### PR TITLE
Exclude openjdk tests for FIPS strict profile

### DIFF
--- a/test/jdk/ProblemList-FIPS140_3_OpenJCEPlusFIPS.FIPS140-3.txt
+++ b/test/jdk/ProblemList-FIPS140_3_OpenJCEPlusFIPS.FIPS140-3.txt
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2024, 2024 All Rights Reserved
+# (c) Copyright IBM Corp. 2024, 2025 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -76,6 +76,7 @@ com/sun/crypto/provider/Cipher/DES/DoFinalReturnLen.java https://github.com/ecli
 com/sun/crypto/provider/Cipher/DES/FlushBug.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 com/sun/crypto/provider/Cipher/DES/KeyWrapping.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 com/sun/crypto/provider/Cipher/DES/PaddingTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+com/sun/crypto/provider/Cipher/DES/PerformanceTest.java https://github.ibm.com/runtimes/backlog/issues/1089 generic-all
 com/sun/crypto/provider/Cipher/DES/Sealtest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 com/sun/crypto/provider/Cipher/DES/TestCipherDES.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 com/sun/crypto/provider/Cipher/DES/TestCipherDESede.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
@@ -158,6 +159,7 @@ com/sun/crypto/provider/TLS/TestPremaster.java https://github.com/eclipse-openj9
 com/sun/org/apache/xml/internal/security/ShortECDSA.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 com/sun/org/apache/xml/internal/security/SignatureKeyInfo.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 com/sun/org/apache/xml/internal/security/TruncateHMAC.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+java/security/AccessController/DoPrivAccompliceTest.java https://github.ibm.com/runtimes/backlog/issues/1089 generic-all
 java/security/BasicPermission/PermClass.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 java/security/BasicPermission/SerialVersion.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 java/security/CodeSigner/Serialize.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
@@ -199,6 +201,7 @@ java/security/MessageDigest/TestDigestIOStream.java https://github.com/eclipse-o
 java/security/MessageDigest/TestSameLength.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 java/security/MessageDigest/TestSameValue.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 java/security/Policy/ExtensiblePolicy/ExtensiblePolicyTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+java/security/Policy/ExtensiblePolicy/ExtensiblePolicyWithJarTest.java https://github.ibm.com/runtimes/jit-crypto/issues/622 generic-all
 java/security/Policy/GetInstance/GetInstance.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 java/security/Policy/GetInstance/GetInstanceSecurity.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 java/security/Policy/SignedJar/SignedJarTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
@@ -432,8 +435,11 @@ sun/security/krb5/runNameEquals.sh https://github.com/eclipse-openj9/openj9/issu
 #
 # Exclude tests list from extended.openjdk
 #
+com/sun/jndi/dns/ConfigTests/TcpTimeout.java https://github.ibm.com/runtimes/backlog/issues/1089 generic-all
 com/sun/jndi/ldap/LdapCBPropertiesTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+com/sun/jndi/ldap/LdapPoolTimeoutTest.java https://github.ibm.com/runtimes/backlog/issues/1089 generic-all
 com/sun/jndi/ldap/LdapSSLHandshakeFailureTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+com/sun/jndi/ldap/LdapTimeoutTest.java https://github.ibm.com/runtimes/backlog/issues/1089 generic-all
 com/sun/jndi/rmi/registry/RegistryContext/ContextWithNullProperties.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 com/sun/jndi/rmi/registry/RegistryContext/UnbindIdempotent.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 com/sun/jndi/rmi/registry/objects/RmiFactoriesFilterTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
@@ -524,6 +530,7 @@ java/sql/testng/test/sql/SQLTransientConnectionExceptionTests.java https://githu
 java/sql/testng/test/sql/SQLTransientExceptionTests.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 java/sql/testng/test/sql/SQLWarningTests.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/naming/module/RunBasic.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+javax/naming/spi/FactoryCacheTest.java https://github.ibm.com/runtimes/backlog/issues/1089 generic-all
 javax/net/ssl/ALPN/SSLEngineAlpnTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/net/ssl/ALPN/SSLServerSocketAlpnTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/net/ssl/ALPN/SSLSocketAlpnTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
@@ -680,6 +687,7 @@ javax/net/ssl/ciphersuites/DisabledAlgorithms.java https://github.com/eclipse-op
 javax/net/ssl/ciphersuites/ECCurvesconstraints.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/net/ssl/ciphersuites/TLSWontNegotiateDisabledCipherAlgos.java#Client https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/net/ssl/ciphersuites/TLSWontNegotiateDisabledCipherAlgos.java#Server https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+javax/net/ssl/ciphersuites/TLSWontNegotiateDisabledCipherAlgos.java https://github.ibm.com/runtimes/backlog/issues/1089 generic-all
 javax/net/ssl/compatibility/ClientHelloProcessing.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/net/ssl/finalize/SSLSessionFinalizeTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/net/ssl/interop/ClientHelloBufferUnderflowException.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
@@ -696,6 +704,8 @@ javax/security/auth/PrivateCredentialPermission/MoreThenOnePrincipals.java https
 javax/security/auth/Subject/SubjectNullTests.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/security/auth/login/Configuration/GetInstance.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/security/auth/login/Configuration/GetInstanceSecurity.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+javax/security/auth/login/modules/JaasModularClientTest.java https://github.ibm.com/runtimes/backlog/issues/1089 generic-all
+javax/security/auth/login/modules/JaasModularDefaultHandlerTest.java https://github.ibm.com/runtimes/backlog/issues/1089 generic-all
 javax/security/sasl/Sasl/ClientServerTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/security/sasl/Sasl/DisabledMechanisms.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/smartcardio/Serialize.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
@@ -722,7 +732,10 @@ jdk/security/jarsigner/Function.java https://github.com/eclipse-openj9/openj9/is
 jdk/security/jarsigner/JarWithOneNonDisabledDigestAlg.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 jdk/security/jarsigner/Properties.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 jdk/security/jarsigner/Spec.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+jdk/security/logging/TestSecurityPropertyModificationLog.java https://github.ibm.com/runtimes/backlog/issues/1089 generic-all
 jdk/security/logging/TestTLSHandshakeLog.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+jdk/security/logging/TestX509CertificateLog.java https://github.ibm.com/runtimes/backlog/issues/1089 generic-all
+jdk/security/logging/TestX509ValidationLog.java https://github.ibm.com/runtimes/backlog/issues/1089 generic-all
 sun/rmi/log/ReliableLog/LogAlignmentTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/rmi/runtime/Log/4504153/Test4504153.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/rmi/runtime/Log/6409194/NoConsoleOutput.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
@@ -769,7 +782,9 @@ sun/security/pkcs/pkcs7/PKCS7VerifyTest.java https://github.com/eclipse-openj9/o
 sun/security/pkcs/pkcs7/SignerOrder.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/pkcs/pkcs8/PKCS8Test.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/pkcs/pkcs8/TestLeadingZeros.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+sun/security/pkcs/pkcs9/PKCS9AttrTypeTests.java https://github.ibm.com/runtimes/backlog/issues/1089 generic-all
 sun/security/pkcs/pkcs9/UnstructuredName.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+sun/security/pkcs11/Config/ReadConfInUTF16Env.java https://github.ibm.com/runtimes/backlog/issues/1089 generic-all
 sun/security/pkcs11/KeyStore/ClientAuth.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/pkcs11/Provider/Absolute.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/pkcs11/sslecc/ClientJSSEServerJSSE.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
@@ -1024,9 +1039,14 @@ sun/security/tools/keytool/fakecacerts/TrustedCert.java https://github.com/eclip
 sun/security/tools/keytool/fakegen/DefaultSignatureAlgorithm.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/tools/keytool/fakegen/PSS.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/util/Debug/DebugOptions.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+sun/security/util/DerInputBuffer/PaddedBitString.java https://github.ibm.com/runtimes/backlog/issues/1089 generic-all
+sun/security/util/DerValue/DeepOctets.java https://github.ibm.com/runtimes/backlog/issues/1089 generic-all
+sun/security/util/DerValue/Indefinite.java https://github.ibm.com/runtimes/backlog/issues/1089 generic-all
+sun/security/util/DerValue/WideTag.java https://github.ibm.com/runtimes/backlog/issues/1089 generic-all
 sun/security/util/HostnameChecker/NullHostnameCheck.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/util/InternalPrivateKey/Correctness.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/util/Oid/S11N.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+sun/security/util/Resources/early/EarlyResources.java https://github.ibm.com/runtimes/backlog/issues/1089 generic-all
 sun/security/validator/EndEntityExtensionCheck.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/validator/PKIXValAndRevCheckTests.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/validator/certreplace.sh https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
@@ -1041,6 +1061,7 @@ sun/security/x509/URICertStore/AIACertTimeout.java https://github.com/eclipse-op
 sun/security/x509/URICertStore/CRLReadTimeout.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/x509/URICertStore/ExtensionsWithLDAP.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/x509/X509CRLImpl/OrderAndDup.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+sun/security/x509/X509CRLImpl/UnexpectedNPE.java https://github.ibm.com/runtimes/backlog/issues/1089 generic-all
 sun/security/x509/X509CRLImpl/Verify.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/x509/X509CertImpl/V3Certificate.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/x509/X509CertImpl/Verify.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all


### PR DESCRIPTION
- Exclude jdk tests for FIPS140_3_OpenJCEPlusFIPS.FIPS140-3

related: [runtimes/automation/issues/170](https://github.ibm.com/runtimes/automation/issues/170)