### PR TITLE
Add selected tracepoints for OpenJ9 -Xtrace

### DIFF
--- a/make/modules/java.base/Lib.gmk
+++ b/make/modules/java.base/Lib.gmk
@@ -24,7 +24,7 @@
 #
 
 # ===========================================================================
-# (c) Copyright IBM Corp. 2018, 2018 All Rights Reserved
+# (c) Copyright IBM Corp. 2018, 2025 All Rights Reserved
 # ===========================================================================
 
 include LibCommon.gmk
@@ -77,6 +77,26 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBNIO, \
     OPTIMIZATION := HIGH, \
     WARNINGS_AS_ERRORS_xlc := false, \
     CFLAGS := $(CFLAGS_JDKLIB), \
+    Net.c_CFLAGS := \
+        -I$(OPENJ9OMR_TOPDIR)/include_core \
+        -I$(OPENJ9_VM_BUILD_DIR)/jcl, \
+    nio_util.c_CFLAGS := \
+        -I$(OPENJ9_TOPDIR)/runtime/include \
+        -I$(OPENJ9_TOPDIR)/runtime/oti \
+        -I$(OPENJ9OMR_TOPDIR)/include_core \
+        -I$(OPENJ9_VM_BUILD_DIR) \
+        -I$(OPENJ9_TOPDIR)/runtime/jcl \
+        -I$(OPENJ9_TOPDIR)/runtime/util \
+        -I$(OPENJ9_VM_BUILD_DIR)/jcl, \
+    SocketDispatcher.c_CFLAGS := \
+        -I$(OPENJ9OMR_TOPDIR)/include_core \
+        -I$(OPENJ9_VM_BUILD_DIR)/jcl, \
+    UnixDispatcher.c_CFLAGS := \
+        -I$(OPENJ9OMR_TOPDIR)/include_core \
+        -I$(OPENJ9_VM_BUILD_DIR)/jcl, \
+    UnixDomainSockets.c_CFLAGS := \
+        -I$(OPENJ9OMR_TOPDIR)/include_core \
+        -I$(OPENJ9_VM_BUILD_DIR)/jcl, \
     EXTRA_HEADER_DIRS := \
         libnio/ch \
         libnio/fs \

--- a/make/modules/java.base/lib/CoreLibraries.gmk
+++ b/make/modules/java.base/lib/CoreLibraries.gmk
@@ -25,6 +25,10 @@
 
 ##########################################################################################
 
+# ===========================================================================
+# (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+# ===========================================================================
+
 LIBVERIFY_OPTIMIZATION := HIGH
 ifeq ($(call isTargetOs, linux), true)
   ifeq ($(COMPILE_WITH_DEBUG_SYMBOLS), true)
@@ -58,8 +62,30 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBJAVA, \
     OPTIMIZATION := HIGH, \
     CFLAGS := $(CFLAGS_JDKLIB) \
         $(LIBJAVA_CFLAGS), \
+    check_version.c_CFLAGS := \
+        -I$(OPENJ9_TOPDIR)/runtime/include \
+        -I$(OPENJ9_TOPDIR)/runtime/oti \
+        -I$(OPENJ9OMR_TOPDIR)/include_core \
+        -I$(OPENJ9_VM_BUILD_DIR) \
+        -I$(OPENJ9_TOPDIR)/runtime/jcl \
+        -I$(OPENJ9_TOPDIR)/runtime/util \
+        -I$(OPENJ9_VM_BUILD_DIR)/jcl, \
+    io_util_md.c_CFLAGS := \
+        -I$(OPENJ9OMR_TOPDIR)/include_core \
+        -I$(OPENJ9_VM_BUILD_DIR)/jcl, \
     jdk_util.c_CFLAGS := $(VERSION_CFLAGS), \
     ProcessImpl_md.c_CFLAGS := $(VERSION_CFLAGS), \
+    UnixFileSystem_md.c_CFLAGS := \
+        -I$(OPENJ9OMR_TOPDIR)/include_core \
+        -I$(OPENJ9_VM_BUILD_DIR)/jcl, \
+    VM.c_CFLAGS := \
+        -I$(OPENJ9_TOPDIR)/runtime/include \
+        -I$(OPENJ9_TOPDIR)/runtime/oti \
+        -I$(OPENJ9OMR_TOPDIR)/include_core \
+        -I$(OPENJ9_VM_BUILD_DIR) \
+        -I$(OPENJ9_TOPDIR)/runtime/jcl \
+        -I$(OPENJ9_TOPDIR)/runtime/util \
+        -I$(OPENJ9_VM_BUILD_DIR)/jcl, \
     WARNINGS_AS_ERRORS_xlc := false, \
     DISABLED_WARNINGS_gcc_ProcessImpl_md.c := unused-result, \
     LDFLAGS := $(LDFLAGS_JDKLIB) \

--- a/src/java.base/share/native/libjava/VM.c
+++ b/src/java.base/share/native/libjava/VM.c
@@ -23,12 +23,25 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+ * ===========================================================================
+ */
+
 #include "jni.h"
 #include "jni_util.h"
 #include "jvm.h"
 #include "jdk_util.h"
 
 #include "jdk_internal_misc_VM.h"
+
+#if defined(WIN32)
+#include "j9access.h"
+/* tracehelp.c defines getTraceInterfaceFromVM(), used by J9_UTINTERFACE_FROM_VM(). */
+#include "tracehelp.c"
+#include "ut_jcl_java.c"
+#endif /* defined(WIN32) */
 
 /* Only register the performance-critical methods */
 static JNINativeMethod methods[] = {
@@ -42,6 +55,11 @@ Java_jdk_internal_misc_VM_latestUserDefinedLoader0(JNIEnv *env, jclass cls) {
 
 JNIEXPORT void JNICALL
 Java_jdk_internal_misc_VM_initialize(JNIEnv *env, jclass cls) {
+#if defined(WIN32)
+    /* Other platforms do this in check_version.c JNI_OnLoad. */
+    UT_JCL_JAVA_MODULE_LOADED(J9_UTINTERFACE_FROM_VM(((J9VMThread *) env)->javaVM));
+#endif /* defined(WIN32) */
+
     // Registers implementations of native methods described in methods[]
     // above.
     // In particular, registers JVM_GetNanoTimeAdjustment as the implementation

--- a/src/java.base/share/native/libjava/check_version.c
+++ b/src/java.base/share/native/libjava/check_version.c
@@ -23,12 +23,30 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+ * ===========================================================================
+ */
+
 #include "jni.h"
 #include "jni_util.h"
 #include "jvm.h"
 
+#if !defined(WIN32)
+#include "j9access.h"
+/* tracehelp.c defines getTraceInterfaceFromVM(), used by J9_UTINTERFACE_FROM_VM(). */
+#include "tracehelp.c"
+#include "ut_jcl_java.c"
+#endif /* !defined(WIN32) */
+
 JNIEXPORT jint JNICALL
 DEF_JNI_OnLoad(JavaVM *vm, void *reserved)
 {
+#if !defined(WIN32)
+    /* Windows doesn't call JNI_OnLoad for libjava.dll, initialize the tracepoint elsewhere. */
+    UT_JCL_JAVA_MODULE_LOADED(J9_UTINTERFACE_FROM_VM((J9JavaVM *)vm));
+#endif /* !defined(WIN32) */
+
     return JNI_VERSION_1_2;
 }

--- a/src/java.base/share/native/libnio/nio_util.c
+++ b/src/java.base/share/native/libnio/nio_util.c
@@ -23,9 +23,20 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+ * ===========================================================================
+ */
+
 #include "jni.h"
 #include "jvm.h"
 #include "jni_util.h"
+
+#include "j9access.h"
+/* tracehelp.c defines getTraceInterfaceFromVM(), used by J9_UTINTERFACE_FROM_VM(). */
+#include "tracehelp.c"
+#include "ut_jcl_nio.c"
 
 JNIEXPORT jint JNICALL
 DEF_JNI_OnLoad(JavaVM *vm, void *reserved)
@@ -35,6 +46,8 @@ DEF_JNI_OnLoad(JavaVM *vm, void *reserved)
     if ((*vm)->GetEnv(vm, (void**) &env, JNI_VERSION_1_2) != JNI_OK) {
         return JNI_EVERSION; /* JNI version not supported */
     }
+
+    UT_JCL_NIO_MODULE_LOADED(J9_UTINTERFACE_FROM_VM((J9JavaVM *)vm));
 
     return JNI_VERSION_1_2;
 }

--- a/src/java.base/unix/native/libjava/UnixFileSystem_md.c
+++ b/src/java.base/unix/native/libjava/UnixFileSystem_md.c
@@ -23,6 +23,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+ * ===========================================================================
+ */
+
 #include <unistd.h>
 #include <assert.h>
 #include <sys/types.h>
@@ -50,6 +56,8 @@
 #include "io_util_md.h"
 #include "java_io_FileSystem.h"
 #include "java_io_UnixFileSystem.h"
+
+#include "ut_jcl_java.h"
 
 #if defined(_AIX)
   #if !defined(NAME_MAX)
@@ -281,6 +289,7 @@ Java_java_io_UnixFileSystem_createFileExclusively0(JNIEnv *env, jclass cls,
                 if (errno != EEXIST)
                     JNU_ThrowIOExceptionWithLastError(env, "Could not open file");
             } else {
+                Trc_io_UnixFileSystem_createFileExclusively_close(fd);
                 if (close(fd) == -1)
                     JNU_ThrowIOExceptionWithLastError(env, "Could not close file");
                 rv = JNI_TRUE;

--- a/src/java.base/unix/native/libjava/io_util_md.c
+++ b/src/java.base/unix/native/libjava/io_util_md.c
@@ -22,6 +22,13 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+ * ===========================================================================
+ */
+
 #include "jni.h"
 #include "jni_util.h"
 #include "jvm.h"
@@ -38,6 +45,8 @@
 #include <linux/fs.h>
 #include <sys/stat.h>
 #endif
+
+#include "ut_jcl_java.h"
 
 #ifdef MACOSX
 
@@ -89,6 +98,11 @@ handleOpen(const char *path, int oflag, int mode) {
             close(fd);
             fd = -1;
         }
+    }
+    if (-1 == fd) {
+        Trc_io_handleOpen_err(path, oflag, mode, 0, 0, errno);
+    } else {
+        Trc_io_handleOpen(path, oflag, mode, 0, 0, (jlong)fd);
     }
     return fd;
 }
@@ -167,6 +181,7 @@ fileDescriptorClose(JNIEnv *env, jobject this)
             dup2(devnull, fd);
             close(devnull);
         }
+        Trc_io_fileDescriptorClose((jlong)fd);
     } else {
         int result;
 #if defined(_AIX)
@@ -176,7 +191,10 @@ fileDescriptorClose(JNIEnv *env, jobject this)
         result = close(fd);
 #endif
         if (result == -1 && errno != EINTR) {
+            Trc_io_fileDescriptorClose_err((jlong)fd, errno);
             JNU_ThrowIOExceptionWithLastError(env, "close failed");
+        } else {
+            Trc_io_fileDescriptorClose((jlong)fd);
         }
     }
 }

--- a/src/java.base/unix/native/libnio/ch/Net.c
+++ b/src/java.base/unix/native/libnio/ch/Net.c
@@ -23,6 +23,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+ * ===========================================================================
+ */
+
 #include <poll.h>
 #include <sys/types.h>
 #include <sys/socket.h>
@@ -30,6 +36,7 @@
 #include <netinet/in.h>
 #include <netinet/tcp.h>
 #include <limits.h>
+#include <arpa/inet.h>
 
 #include "jni.h"
 #include "jni_util.h"
@@ -45,6 +52,8 @@
 #include <stdlib.h>
 #include <sys/utsname.h>
 #endif
+
+#include "ut_jcl_nio.h"
 
 /**
  * IP_MULTICAST_ALL supported since 2.6.31 but may not be available at
@@ -364,12 +373,22 @@ Java_sun_nio_ch_Net_connect0(JNIEnv *env, jclass clazz, jboolean preferIPv6,
     SOCKETADDRESS sa;
     int sa_len = 0;
     int rv;
+    int fd;
 
     if (NET_InetAddressToSockaddr(env, iao, port, &sa, &sa_len, preferIPv6) != 0) {
         return IOS_THROWN;
     }
 
-    rv = connect(fdval(env, fdo), &sa.sa, sa_len);
+    fd = fdval(env, fdo);
+    if (AF_INET == sa.sa4.sin_family) {
+        char buf[INET_ADDRSTRLEN];
+        Trc_nio_ch_Net_connect4((jlong)fd, inet_ntop(AF_INET, &sa.sa4.sin_addr, buf, sizeof(buf)), port, sa_len);
+    } else if (AF_INET6 == sa.sa6.sin6_family) {
+        char buf[INET6_ADDRSTRLEN];
+        Trc_nio_ch_Net_connect6((jlong)fd, inet_ntop(AF_INET6, &sa.sa6.sin6_addr, buf, sizeof(buf)), port, ntohl(sa.sa6.sin6_scope_id), sa_len);
+    }
+
+    rv = connect(fd, &sa.sa, sa_len);
     if (rv != 0) {
         if (errno == EINPROGRESS) {
             return IOS_UNAVAILABLE;

--- a/src/java.base/unix/native/libnio/ch/UnixDispatcher.c
+++ b/src/java.base/unix/native/libnio/ch/UnixDispatcher.c
@@ -23,10 +23,18 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+ * ===========================================================================
+ */
+
 #include "nio.h"
 #include "nio_util.h"
 
 #include "sun_nio_ch_UnixDispatcher.h"
+
+#include "ut_jcl_nio.h"
 
 static int preCloseFD = -1;     /* File descriptor to which we dup other fd's
                                    before closing them for real */
@@ -55,6 +63,7 @@ JNIEXPORT void JNICALL
 Java_sun_nio_ch_UnixDispatcher_close0(JNIEnv *env, jclass clazz, jobject fdo)
 {
     jint fd = fdval(env, fdo);
+    Trc_nio_ch_UnixDispatcher_close(fd);
     closeFileDescriptor(env, fd);
 }
 

--- a/src/java.base/unix/native/libnio/ch/UnixDomainSockets.c
+++ b/src/java.base/unix/native/libnio/ch/UnixDomainSockets.c
@@ -23,6 +23,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+ * ===========================================================================
+ */
+
 #include <poll.h>
 #include <sys/types.h>
 #include <sys/socket.h>
@@ -40,6 +46,8 @@
 #include "sun_nio_ch_Net.h"
 #include "nio_util.h"
 #include "nio.h"
+
+#include "ut_jcl_nio.h"
 
 /* Subtle platform differences in how unnamed sockets (empty path)
  * are returned from getsockname()
@@ -132,12 +140,16 @@ Java_sun_nio_ch_UnixDomainSockets_connect0(JNIEnv *env, jclass clazz, jobject fd
     struct sockaddr_un sa;
     int sa_len = 0;
     int rv;
+    int fd;
 
     if (unixSocketAddressToSockaddr(env, path, &sa, &sa_len) != 0) {
         return IOS_THROWN;
     }
 
-    rv = connect(fdval(env, fdo), (struct sockaddr *)&sa, sa_len);
+    fd = fdval(env, fdo);
+    Trc_nio_ch_UnixDomainSockets_connect(fd, sa.sun_path, sa_len);
+
+    rv = connect(fd, (struct sockaddr *)&sa, sa_len);
     if (rv != 0) {
         if (errno == EINPROGRESS) {
             return IOS_UNAVAILABLE;

--- a/src/java.base/windows/native/libjava/io_util_md.c
+++ b/src/java.base/windows/native/libjava/io_util_md.c
@@ -23,6 +23,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+ * ===========================================================================
+ */
+
 #include "jni.h"
 #include "jni_util.h"
 #include "jvm.h"
@@ -41,6 +47,7 @@
 #include <limits.h>
 #include <wincon.h>
 
+#include "ut_jcl_java.h"
 
 static DWORD MAX_INPUT_EVENTS = 2000;
 
@@ -234,12 +241,22 @@ FD winFileHandleOpen(JNIEnv *env, jstring path, int flags)
         FILE_ATTRIBUTE_NORMAL;
     const DWORD flagsAndAttributes = maybeWriteThrough | maybeDeleteOnClose;
     HANDLE h = NULL;
+    char *pathStr = NULL;
 
     WCHAR *pathbuf = pathToNTPath(env, path, JNI_TRUE);
     if (pathbuf == NULL) {
         /* Exception already pending */
         return -1;
     }
+
+    if (TrcEnabled_Trc_io_handleOpen) {
+        int length = WideCharToMultiByte(CP_UTF8, 0, pathbuf, -1, NULL, 0, NULL, NULL);
+        pathStr = malloc(length);
+        if (NULL != pathStr) {
+            WideCharToMultiByte(CP_UTF8, 0, pathbuf, -1, pathStr, length, NULL, NULL);
+        }
+    }
+
     h = CreateFileW(
         pathbuf,            /* Wide char path name */
         access,             /* Read and/or write permission */
@@ -251,9 +268,13 @@ FD winFileHandleOpen(JNIEnv *env, jstring path, int flags)
     free(pathbuf);
 
     if (h == INVALID_HANDLE_VALUE) {
+        Trc_io_handleOpen_err(pathStr, access, sharing, disposition, flagsAndAttributes, GetLastError());
+        free(pathStr);
         throwFileNotFoundException(env, path);
         return -1;
     }
+    Trc_io_handleOpen(pathStr, access, sharing, disposition, flagsAndAttributes, (jlong)h);
+    free(pathStr);
     return (jlong) h;
 }
 
@@ -557,7 +578,10 @@ fileDescriptorClose(JNIEnv *env, jobject this)
     }
 
     if (CloseHandle(h) == 0) { /* Returns zero on failure */
+        Trc_io_fileDescriptorClose_err((jlong)fd, GetLastError());
         JNU_ThrowIOExceptionWithLastError(env, "close failed");
+    } else {
+        Trc_io_fileDescriptorClose((jlong)fd);
     }
 }
 

--- a/src/java.base/windows/native/libnio/ch/Net.c
+++ b/src/java.base/windows/native/libnio/ch/Net.c
@@ -23,6 +23,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+ * ===========================================================================
+ */
+
 #include <windows.h>
 #include <winsock2.h>
 
@@ -36,6 +42,8 @@
 
 #include "sun_nio_ch_Net.h"
 #include "sun_nio_ch_PollArrayWrapper.h"
+
+#include "ut_jcl_nio.h"
 
 /**
  * Definitions to allow for building with older SDK include files.
@@ -237,6 +245,14 @@ Java_sun_nio_ch_Net_connect0(JNIEnv *env, jclass clazz, jboolean preferIPv6, job
      */
     if (so_rv == 0 && type == SOCK_STREAM && IS_LOOPBACK_ADDRESS(&sa)) {
         NET_EnableFastTcpLoopbackConnect((jint)s);
+    }
+
+    if (AF_INET == sa.sa4.sin_family) {
+        char buf[INET_ADDRSTRLEN];
+        Trc_nio_ch_Net_connect4((jlong)s, inet_ntop(AF_INET, &sa.sa4.sin_addr, buf, sizeof(buf)), port, sa_len);
+    } else if (AF_INET6 == sa.sa6.sin6_family) {
+        char buf[INET6_ADDRSTRLEN];
+        Trc_nio_ch_Net_connect6((jlong)s, inet_ntop(AF_INET6, &sa.sa6.sin6_addr, buf, sizeof(buf)), port, ntohl(sa.sa6.sin6_scope_id), sa_len);
     }
 
     rv = connect(s, &sa.sa, sa_len);

--- a/src/java.base/windows/native/libnio/ch/SocketDispatcher.c
+++ b/src/java.base/windows/native/libnio/ch/SocketDispatcher.c
@@ -23,6 +23,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+ * ===========================================================================
+ */
+
 #include <windows.h>
 #include <winsock2.h>
 #include <ctype.h>
@@ -33,6 +39,8 @@
 #include "sun_nio_ch_SocketDispatcher.h"
 #include "nio.h"
 #include "nio_util.h"
+
+#include "ut_jcl_nio.h"
 
 
 /**************************************************************
@@ -282,6 +290,7 @@ Java_sun_nio_ch_SocketDispatcher_writev0(JNIEnv *env, jclass clazz,
 JNIEXPORT void JNICALL
 Java_sun_nio_ch_SocketDispatcher_close0(JNIEnv *env, jclass clazz, jint fd)
 {
+    Trc_nio_ch_SocketDispatcher_close(fd);
     if (closesocket(fd) == SOCKET_ERROR) {
         JNU_ThrowIOExceptionWithLastError(env, "Socket close failed");
     }

--- a/src/java.base/windows/native/libnio/ch/UnixDomainSockets.c
+++ b/src/java.base/windows/native/libnio/ch/UnixDomainSockets.c
@@ -23,6 +23,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+ * ===========================================================================
+ */
+
 #include <windows.h>
 #include <winsock2.h>
 
@@ -37,6 +43,8 @@
 #include "java_net_InetAddress.h"
 #include "sun_nio_ch_Net.h"
 #include "sun_nio_ch_PollArrayWrapper.h"
+
+#include "ut_jcl_nio.h"
 
 /* The winsock provider ID of the Microsoft AF_UNIX implementation */
 static GUID MS_PROVIDER_ID  = {0xA00943D9,0x9C2E,0x4633,{0x9B,0x59,0,0x57,0xA3,0x16,0x09,0x94}};
@@ -195,12 +203,16 @@ Java_sun_nio_ch_UnixDomainSockets_connect0(JNIEnv *env, jclass clazz, jobject fd
     struct sockaddr_un sa;
     int sa_len = 0;
     int rv;
+    int fd;
 
     if (unixSocketAddressToSockaddr(env, addr, &sa, &sa_len) != 0) {
         return IOS_THROWN;
     }
 
-    rv = connect(fdval(env, fdo), (const struct sockaddr *)&sa, sa_len);
+    fd = fdval(env, fdo);
+    Trc_nio_ch_UnixDomainSockets_connect(fd, sa.sun_path, sa_len);
+
+    rv = connect(fd, (const struct sockaddr *)&sa, sa_len);
     if (rv != 0) {
         int err = WSAGetLastError();
         if (err == WSAEINPROGRESS || err == WSAEWOULDBLOCK) {


### PR DESCRIPTION
Depends on https://github.com/eclipse-openj9/openj9/pull/20936

Issue https://github.ibm.com/runtimes/semeru-requests/issues/46

Linux jcl_java(io) tracepoints
```
22:38:32.472 0x25a00        jcl_java.2         - io_handleOpen(filename=myfile.txt, access=0xc2, sharing=0x1b6, creation=0x0, attributes=0x0, handle=13)
22:38:32.472 0x25a00        jcl_java.4         - io_createFileExclusively_close(handle=13)
22:38:32.472 0x25a00        jcl_java.2         - io_handleOpen(filename=myfile2.txt, access=0x241, sharing=0x1b6, creation=0x0, attributes=0x0, handle=13)
22:38:32.472 0x25a00        jcl_java.0         - io_fileDescriptorClose(handle=13)
```
Linux jcl_nio tracepoints
```
23:11:24.892*0x25a00         jcl_nio.1         - nio_ch_Net_Connect(descriptor=13, connect_to(AF_INET6: addr=::ffff:127.0.0.1 port=37149 scope_id=0), length=28)
23:11:24.892 0x25a00         jcl_nio.3         - nio_ch_UnixDispatcher_close(descriptor=13)
23:11:24.896 0x25a00         jcl_nio.1         - nio_ch_Net_Connect(descriptor=13, connect_to(AF_INET6: addr=::ffff:127.0.0.1 port=37149 scope_id=0), length=28)
23:11:24.896 0x25a00         jcl_nio.3         - nio_ch_UnixDispatcher_close(descriptor=13)

23:12:06.004*0x25a00         jcl_nio.0         - nio_ch_Net_Connect(descriptor=11, connect_to(AF_INET: addr=127.0.0.1 port=43195), length=16)
23:12:06.005 0x25a00         jcl_nio.3         - nio_ch_UnixDispatcher_close(descriptor=11)
23:12:06.008 0x25a00         jcl_nio.0         - nio_ch_Net_Connect(descriptor=11, connect_to(AF_INET: addr=127.0.0.1 port=43195), length=16)
23:12:06.008 0x25a00         jcl_nio.3         - nio_ch_UnixDispatcher_close(descriptor=11)
```

Windows jcl_java(io) tracepoints
```
23:13:51.095 0x25a00        jcl_java.2         - io_handleOpen(filename=myfile2.txt, access=0x40000000, sharing=0x3, creation=0x2, attributes=0x80, handle=2072)
23:13:51.095 0x25a00        jcl_java.0         - io_fileDescriptorClose(handle=2072)
```
Windows jcl_nio tracepoints
```
23:14:28.609*0x25a00         jcl_nio.1         - nio_ch_Net_Connect(descriptor=2092, connect_to(AF_INET6: addr=::ffff:127.0.0.1 port=56507 scope_id=0), length=28)
23:14:28.609 0x25a00         jcl_nio.4         - nio_ch_SocketDispatcher_close(descriptor=2092)
23:14:28.609 0x25a00         jcl_nio.1         - nio_ch_Net_Connect(descriptor=2092, connect_to(AF_INET6: addr=::ffff:127.0.0.1 port=56507 scope_id=0), length=28)
23:14:28.609 0x25a00         jcl_nio.4         - nio_ch_SocketDispatcher_close(descriptor=2092)

23:15:29.958*0x25a00         jcl_nio.0         - nio_ch_Net_Connect(descriptor=2088, connect_to(AF_INET: addr=127.0.0.1 port=56511), length=16)
23:15:29.958 0x25a00         jcl_nio.4         - nio_ch_SocketDispatcher_close(descriptor=2088)
23:15:29.958 0x25a00         jcl_nio.0         - nio_ch_Net_Connect(descriptor=2088, connect_to(AF_INET: addr=127.0.0.1 port=56511), length=16)
23:15:29.958 0x25a00         jcl_nio.4         - nio_ch_SocketDispatcher_close(descriptor=2088)
```

amac jcl_java(io) tracepoints
```
19:01:45.073 0x13908c500        jcl_java.2         - io_handleOpen(filename=myfile.txt, access=0xa02, sharing=0x1b6, creation=0x0, attributes=0x0, handle=10)
19:01:45.073 0x13908c500        jcl_java.4         - io_createFileExclusively_close(handle=10)
19:01:45.073 0x13908c500        jcl_java.2         - io_handleOpen(filename=myfile2.txt, access=0x601, sharing=0x1b6, creation=0x0, attributes=0x0, handle=10)
19:01:45.073 0x13908c500        jcl_java.0         - io_fileDescriptorClose(handle=10)
```

amac jcl_nio tracepoints
```
18:58:01.679*0x15c889f00         jcl_nio.1         - nio_ch_Net_Connect(descriptor=10, connect_to(AF_INET6: addr=::ffff:127.0.0.1 port=57786 scope_id=0), length=28)
18:58:01.682 0x15c889f00         jcl_nio.3         - nio_ch_UnixDispatcher_close(descriptor=10)
18:58:01.684 0x15c889f00         jcl_nio.1         - nio_ch_Net_Connect(descriptor=10, connect_to(AF_INET6: addr=::ffff:127.0.0.1 port=57786 scope_id=0), length=28)
18:58:01.684 0x15c889f00         jcl_nio.3         - nio_ch_UnixDispatcher_close(descriptor=10)

18:59:59.355*0x12a08a300         jcl_nio.0         - nio_ch_Net_Connect(descriptor=10, connect_to(AF_INET: addr=127.0.0.1 port=57789), length=16)
18:59:59.358 0x12a08a300         jcl_nio.3         - nio_ch_UnixDispatcher_close(descriptor=10)
18:59:59.360 0x12a08a300         jcl_nio.0         - nio_ch_Net_Connect(descriptor=10, connect_to(AF_INET: addr=127.0.0.1 port=57789), length=16)
18:59:59.360 0x12a08a300         jcl_nio.3         - nio_ch_UnixDispatcher_close(descriptor=10)
```

xmac jcl_java(io) tracepoints
```
19:09:28.731 0x92c3000        jcl_java.2         - io_handleOpen(filename=myfile.txt, access=0xa02, sharing=0x1b6, creation=0x0, attributes=0x0, handle=10)
19:09:28.731 0x92c3000        jcl_java.4         - io_createFileExclusively_close(handle=10)
19:09:28.731 0x92c3000        jcl_java.2         - io_handleOpen(filename=myfile2.txt, access=0x601, sharing=0x1b6, creation=0x0, attributes=0x0, handle=10)
19:09:28.731 0x92c3000        jcl_java.0         - io_fileDescriptorClose(handle=10)
```

xmac jcl_nio tracepoints
```
19:07:27.308*0x12ba0000         jcl_nio.1         - nio_ch_Net_Connect(descriptor=10, connect_to(AF_INET6: addr=::ffff:127.0.0.1 port=55684 scope_id=0), length=28)
19:07:27.315 0x12ba0000         jcl_nio.3         - nio_ch_UnixDispatcher_close(descriptor=10)
19:07:27.330 0x12ba0000         jcl_nio.1         - nio_ch_Net_Connect(descriptor=10, connect_to(AF_INET6: addr=::ffff:127.0.0.1 port=55684 scope_id=0), length=28)
19:07:27.330 0x12ba0000         jcl_nio.3         - nio_ch_UnixDispatcher_close(descriptor=10)

19:08:26.331*0x1795e000         jcl_nio.0         - nio_ch_Net_Connect(descriptor=10, connect_to(AF_INET: addr=127.0.0.1 port=55687), length=16)
19:08:26.336 0x1795e000         jcl_nio.3         - nio_ch_UnixDispatcher_close(descriptor=10)
19:08:26.343 0x1795e000         jcl_nio.0         - nio_ch_Net_Connect(descriptor=10, connect_to(AF_INET: addr=127.0.0.1 port=55687), length=16)
19:08:26.344 0x1795e000         jcl_nio.3         - nio_ch_UnixDispatcher_close(descriptor=10)
```

AIX jcl_java(io) tracepoints
```
19:05:45.718 0x30010700        jcl_java.2         - io_handleOpen(filename=myfile.txt, access=0x502, sharing=0x1b6, creation=0x0, attributes=0x0, handle=5)
19:05:45.718 0x30010700        jcl_java.4         - io_createFileExclusively_close(handle=5)
19:05:45.718 0x30010700        jcl_java.2         - io_handleOpen(filename=myfile2.txt, access=0x301, sharing=0x1b6, creation=0x0, attributes=0x0, handle=5)
19:05:45.719 0x30010700        jcl_java.0         - io_fileDescriptorClose(handle=5)
```

AIX jcl_net tracepoints
```
19:06:34.138*0x30010700         jcl_nio.1         - nio_ch_Net_Connect(descriptor=8, connect_to(AF_INET6: addr=::ffff:127.0.0.1 port=40882 scope_id=0), length=28)
19:06:34.157 0x30010700         jcl_nio.3         - nio_ch_UnixDispatcher_close(descriptor=8)
19:06:34.163 0x30010700         jcl_nio.1         - nio_ch_Net_Connect(descriptor=8, connect_to(AF_INET6: addr=::ffff:127.0.0.1 port=40882 scope_id=0), length=28)
19:06:34.164 0x30010700         jcl_nio.3         - nio_ch_UnixDispatcher_close(descriptor=8)

19:06:56.324*0x30010700         jcl_nio.0         - nio_ch_Net_Connect(descriptor=5, connect_to(AF_INET: addr=127.0.0.1 port=40885), length=16)
19:06:56.328 0x30010700         jcl_nio.3         - nio_ch_UnixDispatcher_close(descriptor=5)
19:06:56.334 0x30010700         jcl_nio.0         - nio_ch_Net_Connect(descriptor=5, connect_to(AF_INET: addr=127.0.0.1 port=40885), length=16)
19:06:56.335 0x30010700         jcl_nio.3         - nio_ch_UnixDispatcher_close(descriptor=5)
```