### PR TITLE
Update getState() API to use holder.threadStatus field

### DIFF
--- a/src/java.base/share/classes/java/lang/Thread.java
+++ b/src/java.base/share/classes/java/lang/Thread.java
@@ -2793,20 +2793,52 @@ public class Thread implements Runnable {
     }
 
     /**
+     * Returns the translation from a J9VMThread state to a Thread::State.
+     *
+     * @param status thread status value set by VM.
+     * @return this thread's state.
+     *
+     * @see State
+     */
+    private State translateJ9VMThreadStateToThreadState(int status) {
+        switch (status) {
+        case 0x1:   // J9VMTHREAD_STATE_RUNNING
+            return State.RUNNABLE;
+        case 0x2:   // J9VMTHREAD_STATE_BLOCKED
+            return State.BLOCKED;
+        case 0x4:   // J9VMTHREAD_STATE_WAITING
+        case 0x80:  // J9VMTHREAD_STATE_PARKED
+            return State.WAITING;
+        case 0x8:   // J9VMTHREAD_STATE_SLEEPING
+        case 0x40:  // J9VMTHREAD_STATE_WAITING_TIMED
+        case 0x100: // J9VMTHREAD_STATE_PARKED_TIMED
+            return State.TIMED_WAITING;
+        case 0x20:  // J9VMTHREAD_STATE_DEAD
+            return State.TERMINATED;
+        default:
+            synchronized (interruptLock) {
+                if (eetop == NO_REF) {
+                    return State.TERMINATED;
+                }
+                return State.values()[getStateImpl(eetop)];
+            }
+        }
+    }
+
+    /**
      * Returns the state of this thread.
      * This method can be used instead of getState as getState is not final and
      * so can be overridden to run arbitrary code.
      */
     State threadState() {
-        synchronized (interruptLock) {
+        if (started) {
             if (eetop == NO_REF) {
-                if (isDead()) {
-                    return State.TERMINATED;
-                }
-                return State.NEW;
+                return State.TERMINATED;
             }
-            return State.values()[getStateImpl(eetop)];
+            return translateJ9VMThreadStateToThreadState(
+                    (holder != null) ? holder.threadStatus : 0);
         }
+        return State.NEW;
     }
 
     /**


### PR DESCRIPTION
depend: https://github.com/eclipse-openj9/openj9/pull/21043
Rework of https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/879