### PR TITLE
Allow use of conditional code in DDR tools

### DIFF
--- a/closed/DDR.gmk
+++ b/closed/DDR.gmk
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2018, 2022 All Rights Reserved
+# (c) Copyright IBM Corp. 2018, 2025 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -42,7 +42,7 @@ include $(TOPDIR)/make/common/MakeBase.gmk
 include $(TOPDIR)/make/common/JavaCompilation.gmk
 
 # The main source directory.
-DDR_VM_SRC_ROOT := $(OPENJ9_TOPDIR)/debugtools/DDR_VM/src
+DDR_VM_SRC_ROOT := $(J9JCL_SOURCES_DIR)/openj9.dtfj/share/classes
 
 # The top-level directory for intermediate artifacts.
 DDR_SUPPORT_DIR := $(SUPPORT_OUTPUTDIR)/ddr
@@ -171,7 +171,7 @@ $(eval $(call SetupJavaCompilation,BUILD_J9DDR_TEST_CLASSES, \
 		--system none, \
 	BIN := $(DDR_TEST_BIN), \
 	CLASSPATH := $(DDR_CLASSES_BIN), \
-	SRC := $(J9JCL_SOURCES_DIR)/openj9.dtfj/share/classes \
+	SRC := $(DDR_VM_SRC_ROOT) \
 	))
 
 .PHONY : compile_check


### PR DESCRIPTION
This is a simplified back-port of https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/933. Here we don't need two copies of DDR source because all versions that could possibly be involved include the objectweb.asm package needed for Java 21.