### PR TITLE
Support native PBKDF2

### DIFF
--- a/closed/src/java.base/share/classes/jdk/crypto/jniprovider/NativeCrypto.java
+++ b/closed/src/java.base/share/classes/jdk/crypto/jniprovider/NativeCrypto.java
@@ -43,12 +43,14 @@ import openj9.internal.criu.InternalCRIUSupport;
 public class NativeCrypto {
 
     /* Define constants for the native digest algorithm indices. */
-    public static final int SHA1_160 = 0;
-    public static final int SHA2_224 = 1;
-    public static final int SHA2_256 = 2;
-    public static final int SHA5_384 = 3;
-    public static final int SHA5_512 = 4;
-    public static final int MD5 = 5;
+    public static final int MD5 = 0;
+    public static final int SHA1_160 = 1;
+    public static final int SHA2_224 = 2;
+    public static final int SHA2_256 = 3;
+    public static final int SHA5_384 = 4;
+    public static final int SHA5_512 = 5;
+    public static final int SHA5_512_224 = 6;
+    public static final int SHA5_512_256 = 7;
 
     /* Define constants for the EC field types. */
     public static final int ECField_Fp = 0;
@@ -520,4 +522,11 @@ public class NativeCrypto {
                                               byte[] computedSecret,
                                               int computedSecretLength,
                                               int curveType);
+
+    /* Password based key derivation functions (PBKDF). */
+    public final native byte[] PBKDF2Derive(byte[] password,
+                                            byte[] salt,
+                                            int iterations,
+                                            int keyLength,
+                                            int hashAlgorithm);
 }

--- a/src/java.base/share/classes/com/sun/crypto/provider/PBKDF2KeyImpl.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/PBKDF2KeyImpl.java
@@ -24,7 +24,7 @@
  */
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * (c) Copyright IBM Corp. 2023, 2025 All Rights Reserved
  * ===========================================================================
  */
 
@@ -48,9 +48,11 @@ import javax.crypto.spec.PBEKeySpec;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
+import jdk.crypto.jniprovider.NativeCrypto;
 import jdk.internal.ref.CleanerFactory;
 
 import openj9.internal.security.RestrictedSecurity;
+import sun.security.action.GetPropertyAction;
 
 /**
  * This class represents a PBE key derived using PBKDF2 defined
@@ -66,6 +68,11 @@ final class PBKDF2KeyImpl implements javax.crypto.interfaces.PBEKey {
 
     @java.io.Serial
     private static final long serialVersionUID = -2234868909660948157L;
+
+    private static final boolean useNativePBKDF2 = Boolean.getBoolean(
+            GetPropertyAction.privilegedGetProperty("jdk.nativePBKDF2"));
+    private static NativeCrypto nativeCrypto;
+    private static final boolean nativeCryptTrace = NativeCrypto.isTraceEnabled();
 
     private final char[] passwd;
     private final byte[] salt;
@@ -122,7 +129,52 @@ final class PBKDF2KeyImpl implements javax.crypto.interfaces.PBEKey {
             } else {
                 this.prf = Mac.getInstance(prfAlgo, SunJCE.getInstance());
             }
-            this.key = deriveKey(prf, passwdBytes, salt, iterCount, keyLength);
+            nativePBKDF2:
+            if (useNativePBKDF2
+                && (NativeCrypto.getVersionIfAvailable() >= NativeCrypto.OPENSSL_VERSION_3_0_0)
+            ) {
+                int hashIndex;
+                switch (prfAlgo) {
+                case "HmacSHA1":
+                    hashIndex = NativeCrypto.SHA1_160;
+                    break;
+                case "HmacSHA224":
+                    hashIndex = NativeCrypto.SHA2_224;
+                    break;
+                case "HmacSHA256":
+                    hashIndex = NativeCrypto.SHA2_256;
+                    break;
+                case "HmacSHA384":
+                    hashIndex = NativeCrypto.SHA5_384;
+                    break;
+                case "HmacSHA512":
+                    hashIndex = NativeCrypto.SHA5_512;
+                    break;
+                case "HmacSHA512/224":
+                    hashIndex = NativeCrypto.SHA5_512_224;
+                    break;
+                case "HmacSHA512/256":
+                    hashIndex = NativeCrypto.SHA5_512_256;
+                    break;
+                default:
+                    if (nativeCryptTrace) {
+                        System.err.println("The algorithm " + prfAlgo
+                                + " is not supported in native code, using Java implementation.");
+                    }
+                    break nativePBKDF2;
+                }
+                if (nativeCrypto == null) {
+                    nativeCrypto = NativeCrypto.getNativeCrypto();
+                }
+                key = nativeCrypto.PBKDF2Derive(passwdBytes, salt, iterCount, keyLength / 8, hashIndex);
+                if ((key == null) && nativeCryptTrace) {
+                    System.err.println("Native PBKDF2 failed for algorithm " + prfAlgo
+                            + ", using Java implementation.");
+                }
+            }
+            if (key == null) {
+                key = deriveKey(prf, passwdBytes, salt, iterCount, keyLength);
+            }
         } catch (NoSuchAlgorithmException nsae) {
             // not gonna happen; re-throw just in case
             throw new InvalidKeySpecException(nsae);


### PR DESCRIPTION
A native implementation of the following PBKDF2
related crypto sevices are supported to optimze
the PBKDF2 key derivations performance.

- PBKDF2WithHmacSHA1
- PBKDF2WithHmacSHA224
- PBKDF2WithHmacSHA256
- PBKDF2WithHmacSHA384
- PBKDF2WithHmacSHA512
- PBKDF2WithHmacSHA512/224
- PBKDF2WithHmacSHA512/256

A new JVM option (jdk.nativePBKDF2) is provided to enable the use of the native PBKDF2 implementation, which is disabled by default.