### PR TITLE
Add strcmp to the AIX list of missing libc functions

### DIFF
--- a/closed/src/java.base/aix/native/libsyslookup/syslookup.c
+++ b/closed/src/java.base/aix/native/libsyslookup/syslookup.c
@@ -1,6 +1,6 @@
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2023, 2024 All Rights Reserved
+ * (c) Copyright IBM Corp. 2023, 2025 All Rights Reserved
  * ===========================================================================
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,7 +33,7 @@
 static void *funcs[] = {
     &bcopy, &endfsent, &getfsent, &getfsfile, &getfsspec, &longjmp,
     &memcpy, &memmove, &setfsent, &setjmp, &siglongjmp, &strcat,
-    &strcpy, &strncat, &strncpy
+    &strcmp, &strcpy, &strncat, &strncpy
 };
 
 __attribute__((visibility("default"))) void **

--- a/src/java.base/share/classes/jdk/internal/foreign/SystemLookup.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/SystemLookup.java
@@ -25,7 +25,7 @@
 
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2022, 2024 All Rights Reserved
+ * (c) Copyright IBM Corp. 2022, 2025 All Rights Reserved
  * ===========================================================================
  */
 
@@ -283,7 +283,7 @@ public final class SystemLookup implements SymbolLookup {
     public enum AixFuncSymbols {
         bcopy, endfsent, getfsent, getfsfile, getfsspec, longjmp,
         memcpy, memmove, setfsent, setjmp, siglongjmp, strcat,
-        strcpy, strncat, strncpy
+        strcmp, strcpy, strncat, strncpy
         ;
 
         static AixFuncSymbols valueOfOrNull(String name) {


### PR DESCRIPTION
Fixes https://github.com/eclipse-openj9/openj9/issues/21464

Personal build https://hyc-runtimes-jenkins.swg-devops.com/view/OpenJ9%20-%20Personal/job/Pipeline-Build-Test-Personal/27262

Testing https://hyc-runtimes-jenkins.swg-devops.com/view/Test_grinder/job/Grinder/49033/ - passed