### PR TITLE
Use PrivilegedAction to use StackWalker with RETAIN_CLASS_REFERENCE option

### DIFF
--- a/closed/src/java.base/share/classes/openj9/internal/security/RestrictedSecurity.java
+++ b/closed/src/java.base/share/classes/openj9/internal/security/RestrictedSecurity.java
@@ -191,11 +191,20 @@ public final class RestrictedSecurity {
      * extending profiles, instead of altering them, a digest of the profile
      * is calculated and compared to the expected value.
      */
+    @SuppressWarnings("removal")
     private static void checkHashValues() {
         ProfileParser parser = profileParser;
-        if ((parser != null) && !isJarVerifierInStackTrace()) {
-            profileParser = null;
-            parser.checkHashValues();
+        if (parser != null) {
+            boolean isVerifying;
+            if (System.getSecurityManager() == null) {
+                isVerifying = isJarVerifierInStackTrace();
+            } else {
+                isVerifying = AccessController.doPrivileged((PrivilegedAction<Boolean>)(() -> isJarVerifierInStackTrace()));
+            }
+            if (!isVerifying) {
+                profileParser = null;
+                parser.checkHashValues();
+            }
         }
     }
 


### PR DESCRIPTION
If a `SecurityManager` is utilized, permissions are needed to use the `StackWalker` class with the `RETAIN_CLASS_REFERENCE` option, which `RestrictedSecurity` doesn't have. A `PrivilegedAction` is used to allow said action in this case.

Signed-off-by: Kostas Tsiounis <kostas.tsiounis@ibm.com>