### PR TITLE
Update the ProblemList-OpenJCEPlus test exclusion list

### DIFF
--- a/test/jdk/ProblemList-OpenJCEPlus.txt
+++ b/test/jdk/ProblemList-OpenJCEPlus.txt
@@ -17,3 +17,12 @@
 # You should have received a copy of the GNU General Public License version
 # 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
 # ===========================================================================
+#
+# Exclude tests list from jdk_security tests
+#
+java/security/SecureRandom/DefaultAlgo.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/994 generic-all
+java/security/SecureRandom/DefaultProvider.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/994 generic-all
+java/security/Signature/SignatureGetInstance.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/994 generic-all
+sun/security/ec/ed/TestEdDSA.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/994 generic-all
+sun/security/jca/PreferredProviderNegativeTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/994 generic-all
+sun/security/provider/all/Deterministic.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/994 generic-all


### PR DESCRIPTION
This is a back port PR from PR https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/993 for v0.51.0-release branch.

This commit updates the ProblemList-OpenJCEPlus test exclusion list in accordance with issue https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/994