### PR TITLE
Enable native PBKDF2 as default

### DIFF
--- a/src/java.base/share/classes/com/sun/crypto/provider/PBKDF2KeyImpl.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/PBKDF2KeyImpl.java
@@ -69,8 +69,7 @@ final class PBKDF2KeyImpl implements javax.crypto.interfaces.PBEKey {
     @java.io.Serial
     private static final long serialVersionUID = -2234868909660948157L;
 
-    private static final boolean useNativePBKDF2 = Boolean.parseBoolean(
-            GetPropertyAction.privilegedGetProperty("jdk.nativePBKDF2"));
+    private static final boolean useNativePBKDF2 = NativeCrypto.isAlgorithmEnabled("jdk.nativePBKDF2", "PBKDF2");
     private static NativeCrypto nativeCrypto;
     private static final boolean nativeCryptTrace = NativeCrypto.isTraceEnabled();
 


### PR DESCRIPTION
Switch the default implementation of PBKDF2 related crypto services from java to native.

Backport from: https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/1015