### PR TITLE
Improve building OpenSSL on Windows

### DIFF
--- a/closed/openssl.gmk
+++ b/closed/openssl.gmk
@@ -109,7 +109,7 @@ endif # CCACHE
 
 build_openssl :
 	@$(ECHO) Compiling OpenSSL in $(OPENSSL_DIR) for $(OPENSSL_TARGET)$(if $(OPENSSL_CONFIG_CFLAGS), with additional CFLAGS $(OPENSSL_CONFIG_CFLAGS))
-	( $(OPENSSL_CONFIG_SETUP) $(CD) $(OPENSSL_DIR) && $(PERL) Configure $(OPENSSL_CONFIG_CFLAGS) $(OPENSSL_TARGET) shared )
+	( $(OPENSSL_CONFIG_SETUP) $(CD) $(OPENSSL_DIR) && $(PERL) Configure $(OPENSSL_CONFIG_CFLAGS) $(OPENSSL_TARGET) no-makedepend shared )
 	$(OPENSSL_PATCH)
 	+ ( $(OPENSSL_MAKE_SETUP) $(CD) $(OPENSSL_DIR) && $(OPENSSL_MAKE) )
 


### PR DESCRIPTION
Add configuration option `no-makedepend` which, according to [NOTES-WINDOWS.md](https://github.com/openssl/openssl/blob/master/NOTES-WINDOWS.md), "can speed up build times by up to 50%". Specifying that option appears to have no effect on other platforms.

This is a backport of https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/1025.