### PR TITLE
Generate keypair using tested provider

### DIFF
--- a/test/jdk/sun/security/provider/all/Deterministic.java
+++ b/test/jdk/sun/security/provider/all/Deterministic.java
@@ -176,7 +176,7 @@ public class Deterministic {
                 keyAlg = s.getAlgorithm(); // EdDSA etc
             }
         }
-        var sk = generateKeyPair(keyAlg, 0).getPrivate();
+        var sk = generateKeyPair(keyAlg, null, 0).getPrivate();
         var sig = Signature.getInstance(s.getAlgorithm(), s.getProvider());
         try {
             if (keyAlg.equals("RSASSA-PSS")) {
@@ -199,8 +199,8 @@ public class Deterministic {
     static void testKeyPairGenerator(Provider.Service s) throws Exception {
         System.out.println(s.getProvider().getName()
                 + " " + s.getType() + "." + s.getAlgorithm());
-        var kp1 = generateKeyPair(s.getAlgorithm(), 0);
-        var kp2 = generateKeyPair(s.getAlgorithm(), 0);
+        var kp1 = generateKeyPair(s.getAlgorithm(), s.getProvider(), 0);
+        var kp2 = generateKeyPair(s.getAlgorithm(), s.getProvider(), 0);
         Asserts.assertEqualsByteArray(
                 kp1.getPrivate().getEncoded(), kp2.getPrivate().getEncoded());
         Asserts.assertEqualsByteArray(
@@ -211,8 +211,13 @@ public class Deterministic {
         System.out.println("    Passed");
     }
 
-    static KeyPair generateKeyPair(String alg, int offset) throws Exception {
-        var g = KeyPairGenerator.getInstance(alg);
+    static KeyPair generateKeyPair(String alg, Provider provider, int offset) throws Exception {
+        KeyPairGenerator g;
+        if (provider != null) {
+            g = KeyPairGenerator.getInstance(alg, provider);
+        } else {
+            g = KeyPairGenerator.getInstance(alg);
+        }
         var size = switch (g.getAlgorithm()) {
             case "RSA", "RSASSA-PSS", "DSA", "DiffieHellman" -> 1024;
             case "EC" -> 256;
@@ -249,7 +254,7 @@ public class Deterministic {
             g.init(new SeededSecureRandom(SEED + 2));
             return g.generateKey();
         } if (s.equals("RSA")) {
-            return generateKeyPair("RSA", 3).getPublic();
+            return generateKeyPair("RSA", null, 3).getPublic();
         } else {
             var g = KeyGenerator.getInstance(s, p);
             g.init(new SeededSecureRandom(SEED + 4));
@@ -261,7 +266,7 @@ public class Deterministic {
         System.out.println(s.getProvider().getName()
                 + " " + s.getType() + "." + s.getAlgorithm());
         String keyAlg = getKeyAlgFromKEM(s.getAlgorithm());
-        var kp = generateKeyPair(keyAlg, 10);
+        var kp = generateKeyPair(keyAlg, null, 10);
         var kem = KEM.getInstance(s.getAlgorithm(), s.getProvider());
         var e1 = kem.newEncapsulator(kp.getPublic(), null, new SeededSecureRandom(SEED));
         var enc1 = e1.encapsulate();
@@ -278,8 +283,8 @@ public class Deterministic {
         System.out.println(s.getProvider().getName()
                 + " " + s.getType() + "." + s.getAlgorithm());
         String keyAlg = getKeyAlgFromKEM(s.getAlgorithm());
-        var kpS = generateKeyPair(keyAlg, 11);
-        var kpR = generateKeyPair(keyAlg, 12);
+        var kpS = generateKeyPair(keyAlg, null, 11);
+        var kpR = generateKeyPair(keyAlg, null, 12);
         var ka = KeyAgreement.getInstance(s.getAlgorithm(), s.getProvider());
         ka.init(kpS.getPrivate(), new SeededSecureRandom(SEED));
         ka.doPhase(kpR.getPublic(), true);


### PR DESCRIPTION
For the keypair generator tests, the keypairs are generated by the first available provider and not the provider that is to be tested.

With this change the service from the tested provider is explicitly requested where needed.

When a keypair from any provider is good enough, we allow the test to get it from the first available.

Back-ported from: https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/1038

Signed-off-by: Kostas Tsiounis <kostas.tsiounis@ibm.com>