### PR TITLE
Update the exclusion lists for OpenJCEPlus and OpenJCEPlusFIPS tests

### DIFF
--- a/test/jdk/ProblemList-FIPS140_3_OpenJCEPlusFIPS.FIPS140-3.txt
+++ b/test/jdk/ProblemList-FIPS140_3_OpenJCEPlusFIPS.FIPS140-3.txt
@@ -266,6 +266,7 @@ java/security/cert/CertPathValidator/OCSP/AIACheck.java https://github.com/eclip
 java/security/cert/CertPathValidator/OCSP/FailoverToCRL.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 java/security/cert/CertPathValidator/OCSP/GetAndPostTests.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 java/security/cert/CertPathValidator/OCSP/OCSPTimeout.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+java/security/cert/CertPathValidator/crlDP/CheckAllCRLs.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 java/security/cert/CertPathValidator/indirectCRL/CircularCRLOneLevel.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 java/security/cert/CertPathValidator/indirectCRL/CircularCRLOneLevelRevoked.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 java/security/cert/CertPathValidator/indirectCRL/CircularCRLTwoLevel.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
@@ -795,9 +796,12 @@ sun/security/pkcs11/Config/ReadConfInUTF16Env.java https://github.ibm.com/runtim
 sun/security/pkcs11/KeyStore/ClientAuth.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/pkcs11/Provider/Absolute.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/pkcs11/sslecc/ClientJSSEServerJSSE.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+sun/security/pkcs12/AttributesCorrectness.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+sun/security/pkcs12/AttributesMultiThread.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/pkcs12/Bug6415637.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/pkcs12/EmptyPassword.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/pkcs12/GetAttributes.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+sun/security/pkcs12/GetSetEntryTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/pkcs12/KeytoolOpensslInteropTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/pkcs12/P12SecretKey.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/pkcs12/PBES2Encoding.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all

--- a/test/jdk/ProblemList-OpenJCEPlus.txt
+++ b/test/jdk/ProblemList-OpenJCEPlus.txt
@@ -21,6 +21,7 @@
 # Exclude tests list from jdk_security tests
 #
 com/sun/crypto/provider/DHKEM/Compliance.java https://github.ibm.com/runtimes/jit-crypto/issues/773 generic-all
+java/security/Provider/SecurityProviderModularTest.java https://github.com/eclipse-openj9/openj9/issues/22242 generic-all
 java/security/SecureRandom/DefaultAlgo.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/994 generic-all
 java/security/SecureRandom/DefaultProvider.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/994 generic-all
 java/security/SecureRandom/NoSync.java https://github.ibm.com/runtimes/jit-crypto/issues/776 generic-all
@@ -31,4 +32,6 @@ java/security/Signature/SignWithOutputBuffer.java https://github.ibm.com/runtime
 javax/crypto/KeyGenerator/CompareKeys.java https://github.ibm.com/runtimes/jit-crypto/issues/779 generic-all
 sun/security/ec/ed/TestEdDSA.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/994 generic-all
 sun/security/jca/PreferredProviderNegativeTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/994 generic-all
-sun/security/provider/DSA/TestMaxLengthDER.java https://github.com/ https://github.ibm.com/runtimes/jit-crypto/issues/780 generic-all
+sun/security/krb5/auto/principalProperty/PrincipalSystemPropTest.java https://github.com/eclipse-openj9/openj9/issues/22242 generic-all
+sun/security/provider/DSA/TestMaxLengthDER.java https://github.com/eclipse-openj9/openj9/issues/22242 generic-all
+sun/security/util/Debug/DebugOptions.java https://github.com/eclipse-openj9/openj9/issues/22242 generic-all


### PR DESCRIPTION
This is a back-port PR from PR: https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/1052

This PR updates the exclusion lists for the OpenJCEPlus and OpenJCEPlusFIPS tests with the following tests:

TEST_FLAG: OpenJCEPlus

java/security/Provider/SecurityProviderModularTest.java sun/security/krb5/auto/principalProperty/PrincipalSystemPropTest.java
sun/security/provider/DSA/TestMaxLengthDER.java
sun/security/util/Debug/DebugOptions.java

TEST_FLAG: FIPS140_3_OpenJCEPlusFIPS.FIPS140-3

sun/security/pkcs12/AttributesCorrectness.java
sun/security/pkcs12/AttributesMultiThread.java
sun/security/pkcs12/GetSetEntryTest.java
sun/security/pkcs12/KeytoolOpensslInteropTest.java
java/security/cert/CertPathValidator/crlDP/CheckAllCRLs.java

For the above TEST_FLAG FIPS140_3_OpenJCEPlusFIPS.FIPS140-3 excluded tests, some of them may not be backported to all versions.