### PR TITLE
Allow FIPS mode on all Semeru platforms

### DIFF
--- a/closed/src/java.base/share/classes/openj9/internal/security/RestrictedSecurity.java
+++ b/closed/src/java.base/share/classes/openj9/internal/security/RestrictedSecurity.java
@@ -66,7 +66,7 @@ public final class RestrictedSecurity {
     private static final boolean allowSetProperties;
 
     private static final boolean isNSSSupported;
-    private static final boolean isOpenJCEPlusSupported;
+    private static final boolean isOpenJCEPlusCertifiedPlatform;
 
     private static final boolean userSetProfile;
     private static final boolean shouldEnableSecurity;
@@ -85,16 +85,7 @@ public final class RestrictedSecurity {
 
     private static final Set<String> unmodifiableProperties = new HashSet<>();
 
-    private static final Map<String, List<String>> supportedPlatformsNSS = new HashMap<>();
-    private static final Map<String, List<String>> supportedPlatformsOpenJCEPlus = new HashMap<>();
-
     static {
-        supportedPlatformsNSS.put("Arch", List.of("amd64", "ppc64le", "s390x"));
-        supportedPlatformsNSS.put("OS", List.of("Linux"));
-
-        supportedPlatformsOpenJCEPlus.put("Arch", List.of("amd64", "ppc64", "s390x"));
-        supportedPlatformsOpenJCEPlus.put("OS", List.of("Linux", "AIX", "Windows"));
-
         @SuppressWarnings("removal")
         String[] props = AccessController.doPrivileged(
                 new PrivilegedAction<>() {
@@ -107,37 +98,19 @@ public final class RestrictedSecurity {
                                 System.getProperty("semeru.fips.allowsetproperties") };
                     }
                 });
+        final List<String> nssSupportedArch = List.of("amd64", "ppc64le", "s390x");
+        final List<String> openjceplusCertifiedArch = List.of("amd64", "ppc64", "s390x");
+        final List<String> openjceplusCertifiedOS = List.of("AIX", "Linux", "Windows");
+        String osName = props[2];
+        String osArch = props[3];
 
-        boolean isOsSupported, isArchSupported;
         // Check whether the NSS FIPS solution is supported.
-        isOsSupported = false;
-        for (String os: supportedPlatformsNSS.get("OS")) {
-            if (props[2].contains(os)) {
-                isOsSupported = true;
-            }
-        }
-        isArchSupported = false;
-        for (String arch: supportedPlatformsNSS.get("Arch")) {
-            if (props[3].contains(arch)) {
-                isArchSupported = true;
-            }
-        }
-        isNSSSupported = isOsSupported && isArchSupported;
+        isNSSSupported = osName.contains("Linux")
+                && containsAny(osArch, nssSupportedArch);
 
-        // Check whether the OpenJCEPlus FIPS solution is supported.
-        isOsSupported = false;
-        for (String os: supportedPlatformsOpenJCEPlus.get("OS")) {
-            if (props[2].contains(os)) {
-                isOsSupported = true;
-            }
-        }
-        isArchSupported = false;
-        for (String arch: supportedPlatformsOpenJCEPlus.get("Arch")) {
-            if (props[3].contains(arch)) {
-                isArchSupported = true;
-            }
-        }
-        isOpenJCEPlusSupported = isOsSupported && isArchSupported;
+        // Check whether the OpenJCEPlus FIPS solution is certified.
+        isOpenJCEPlusCertifiedPlatform = containsAny(osName, openjceplusCertifiedOS)
+                && containsAny(osArch, openjceplusCertifiedArch);
 
         // Check the default solution to see if FIPS is supported.
         isFIPSSupported = isNSSSupported;
@@ -432,12 +405,14 @@ public final class RestrictedSecurity {
                     + " on this platform.");
         }
 
-        if (profileID.contains("OpenJCEPlus") && !isOpenJCEPlusSupported) {
-            printStackTraceAndExit("OpenJCEPlus RestrictedSecurity profiles are not supported"
-                    + " on this platform.");
-        }
-
         if (debug != null) {
+            if (profileID.contains("OpenJCEPlus")) {
+                if (isOpenJCEPlusCertifiedPlatform) {
+                    debug.println("OpenJCEPlus RestrictedSecurity profile running on a certified platform.");
+                } else {
+                    debug.println("OpenJCEPlus RestrictedSecurity profile running in developer mode.");
+                }
+            }
             debug.println("RestrictedSecurity profile " + profileID
                     + " is supported on this platform.");
         }
@@ -727,6 +702,15 @@ public final class RestrictedSecurity {
      */
     private static boolean isAsterisk(String string) {
         return "*".equals(string);
+    }
+
+    private static boolean containsAny(String string, List<String> substrings) {
+        for (String substring : substrings) {
+            if (string.contains(substring)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/src/java.base/share/conf/security/java.security
+++ b/src/java.base/share/conf/security/java.security
@@ -157,7 +157,6 @@ RestrictedSecurity.NSS.140-2.securerandom.provider = SunPKCS11-NSS-FIPS
 RestrictedSecurity.NSS.140-2.securerandom.algorithm = PKCS11
 #endif
 
-#if defined aix-ppc || defined linux-ppc || defined linux-s390 || defined linux-x86 || defined windows
 #
 # Strict Restricted Security mode profile for FIPS 140-3. This policy represents only allowable
 # approved cryptography in the OpenJCEPlusFIPS provider along with other non-cryptographic algorithms
@@ -347,7 +346,6 @@ RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Weakly-Enforced.jce.provider.9 = or
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Weakly-Enforced.jce.provider.10 = sun.security.smartcardio.SunPCSC
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Weakly-Enforced.jce.provider.11 = sun.security.provider.certpath.ldap.JdkLDAP
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Weakly-Enforced.jce.provider.12 = com.sun.security.sasl.gsskerb.JdkSASL
-#endif
 
 #
 # A list of preferred providers for specific algorithms. These providers will


### PR DESCRIPTION
OpenJCEPlus can now be enabled in developer mode for use on all Semeru platforms. This update allows the restricted security features associated with FIPS 140-3 to be enabled for use including FIPS security profiles associated with the OpenJCEPlusFIPS provider when running in FIPS mode.

Back-ported from: https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/1058

Signed-off-by: Jason Katonica <katonica@us.ibm.com>