### PR TITLE
Exclude Deterministic test when OpenJCEPlus is default

### DIFF
--- a/test/jdk/ProblemList-FIPS140_3_OpenJcePlus.txt
+++ b/test/jdk/ProblemList-FIPS140_3_OpenJcePlus.txt
@@ -772,6 +772,7 @@ sun/security/provider/SecureRandom/StrongSeedReader.java https://github.com/ecli
 sun/security/provider/SeedGenerator/SeedGeneratorChoice.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 sun/security/provider/X509Factory/BadPem.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 sun/security/provider/X509Factory/BigCRL.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
+sun/security/provider/all/Deterministic.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/provider/certpath/DisabledAlgorithms/CPBuilder.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 sun/security/provider/certpath/DisabledAlgorithms/CPBuilderWithMD5.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 sun/security/provider/certpath/DisabledAlgorithms/CPValidatorEndEntity.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all


### PR DESCRIPTION
Back-ported from: https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/1063

Signed-off-by: Kostas Tsiounis <kostas.tsiounis@ibm.com>