### PR TITLE
Add thread safety for generateKeyPair in NativeXDHKeyPairGenerator

### DIFF
--- a/closed/src/jdk.crypto.ec/share/classes/sun/security/ec/NativeXDHKeyPairGenerator.java
+++ b/closed/src/jdk.crypto.ec/share/classes/sun/security/ec/NativeXDHKeyPairGenerator.java
@@ -25,7 +25,7 @@
 
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * (c) Copyright IBM Corp. 2023, 2025 All Rights Reserved
  * ===========================================================================
  */
 
@@ -61,17 +61,19 @@ public class NativeXDHKeyPairGenerator extends KeyPairGeneratorSpi {
     private XECOperations ops;
     private final XECParameters lockedParams;
 
-    private XDHKeyPairGenerator javaImplementation;
+    private final XDHKeyPairGenerator javaImplementation;
     private boolean useJavaImpl;
 
     public NativeXDHKeyPairGenerator() {
         tryInitialize(NamedParameterSpec.X25519);
         lockedParams = null;
+        javaImplementation = initializeJavaImplementation();
     }
 
     private NativeXDHKeyPairGenerator(NamedParameterSpec paramSpec) {
         tryInitialize(paramSpec);
         lockedParams = ops.getParameters();
+        javaImplementation = initializeJavaImplementation();
     }
 
     private void tryInitialize(NamedParameterSpec paramSpec) {
@@ -142,7 +144,7 @@ public class NativeXDHKeyPairGenerator extends KeyPairGeneratorSpi {
          * to generate the keypair.
          */
         if (useJavaImpl) {
-            return javaImplGenerateKeyPair();
+            return javaImplementation.generateKeyPair();
         }
 
         /* If library isn't loaded, use Java implementation. */
@@ -150,7 +152,7 @@ public class NativeXDHKeyPairGenerator extends KeyPairGeneratorSpi {
             if (nativeCryptTrace) {
                 System.err.println("OpenSSL library not loaded. Using Java crypto implementation to generate KeyPair.");
             }
-            return javaImplGenerateKeyPair();
+            return javaImplementation.generateKeyPair();
         }
 
         XECParameters params;
@@ -184,7 +186,7 @@ public class NativeXDHKeyPairGenerator extends KeyPairGeneratorSpi {
             if (nativeCryptTrace) {
                 System.err.println("KeyPair generation by OpenSSL failed, using Java crypto implementation.");
             }
-            return javaImplGenerateKeyPair();
+            return javaImplementation.generateKeyPair();
         }
         try {
             reverse(publicKey);
@@ -211,26 +213,18 @@ public class NativeXDHKeyPairGenerator extends KeyPairGeneratorSpi {
      * Initializes the java implementation.
      * Already set parameters are used to specify the curve type.
      */
-    private void initializeJavaImplementation() {
-        if (javaImplementation == null) {
-            if (lockedParams == null) {
-                javaImplementation = new XDHKeyPairGenerator();
-            } else if (isX25519(lockedParams)) {
-                javaImplementation = new XDHKeyPairGenerator.X25519();
-            } else {
-                javaImplementation = new XDHKeyPairGenerator.X448();
-            }
+    private XDHKeyPairGenerator initializeJavaImplementation() {
+        XDHKeyPairGenerator kpg;
+        if (lockedParams == null) {
+            kpg = new XDHKeyPairGenerator();
+        } else if (isX25519(lockedParams)) {
+            kpg = new XDHKeyPairGenerator.X25519();
+        } else {
+            kpg = new XDHKeyPairGenerator.X448();
         }
 
-        javaImplementation.initialize(ops.getParameters().getBits(), random);
-    }
-
-    /*
-     * Uses the java implementation to generate a KeyPair.
-     */
-    private KeyPair javaImplGenerateKeyPair() {
-        initializeJavaImplementation();
-        return javaImplementation.generateKeyPair();
+        kpg.initialize(ops.getParameters().getBits(), random);
+        return kpg;
     }
 
     private static void swap(byte[] arr, int i, int j) {


### PR DESCRIPTION
NativeXDHKeyPairGenerator is updated to use the correct instance of XDHKeyPairGenerator for varying
curves in multithreaded environment for generateKeyPair() when all the threads share the same instance of KeyPairGenerator.

Back-ported from: https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/1077

Signed-off-by: Dev Agarwal [dev.agarwal@ibm.com](mailto:dev.agarwal@ibm.com)