### PR TITLE
De-duplicate entries in FIPS 140-3 excludes files

### DIFF
--- a/test/jdk/ProblemList-FIPS140_3_OpenJCEPlusFIPS.FIPS140-3.txt
+++ b/test/jdk/ProblemList-FIPS140_3_OpenJCEPlusFIPS.FIPS140-3.txt
@@ -477,7 +477,6 @@ javax/net/ssl/DTLSv10/DTLSv10RehandshakeWithDataExTest.java https://github.com/e
 javax/net/ssl/DTLSv10/DTLSv10SequenceNumberTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/net/ssl/DTLSv10/DTLSv10UnsupportedCiphersTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/net/ssl/finalize/SSLSessionFinalizeTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
-javax/net/ssl/finalize/SSLSessionFinalizeTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/net/ssl/FixingJavadocs/ImplicitHandshake.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/net/ssl/FixingJavadocs/KMTMGetNothing.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/net/ssl/FixingJavadocs/SSLSessionNulls.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all

--- a/test/jdk/ProblemList-FIPS140_3_OpenJcePlus.txt
+++ b/test/jdk/ProblemList-FIPS140_3_OpenJcePlus.txt
@@ -420,7 +420,6 @@ javax/net/ssl/DTLSv10/DTLSv10RehandshakeWithDataExTest.java https://github.com/e
 javax/net/ssl/DTLSv10/DTLSv10SequenceNumberTest.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 javax/net/ssl/DTLSv10/DTLSv10UnsupportedCiphersTest.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 javax/net/ssl/finalize/SSLSessionFinalizeTest.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
-javax/net/ssl/finalize/SSLSessionFinalizeTest.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 javax/net/ssl/FixingJavadocs/ImplicitHandshake.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 javax/net/ssl/FixingJavadocs/KMTMGetNothing.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 javax/net/ssl/FixingJavadocs/SSLSessionNulls.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all


### PR DESCRIPTION
This update removes all duplicate exclusions in FIPS 140-3 exclusion files.

Back-ported from: https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/1104

Signed-off-by: Jason Katonica <katonica@us.ibm.com>