### PR TITLE
Update ProcessBuilder/Basic regex

### DIFF
--- a/test/jdk/java/lang/ProcessBuilder/Basic.java
+++ b/test/jdk/java/lang/ProcessBuilder/Basic.java
@@ -23,7 +23,7 @@
 
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2020, 2022 All Rights Reserved
+ * (c) Copyright IBM Corp. 2020, 2025 All Rights Reserved
  * ===========================================================================
  */
 
@@ -94,8 +94,8 @@ public class Basic {
     static final String libpath = System.getenv("LIBPATH");
 
     /* Used for regex String matching for long error messages */
-    static final String PERMISSION_DENIED_ERROR_MSG = "(Permission denied|error=13)";
-    static final String NO_SUCH_FILE_ERROR_MSG = "(No such file|error=2)";
+    static final String PERMISSION_DENIED_ERROR_MSG = "(Permission denied|error: 13)";
+    static final String NO_SUCH_FILE_ERROR_MSG = "(No such file|error: 2)";
     static final String SPAWNHELPER_FAILURE_MSG = "(Possible reasons:)";
 
     /**


### PR DESCRIPTION
A change that should have been made upstream in
* [8352533: Report useful IOExceptions when jspawnhelper fails](https://github.com/keithc-ca/openj9-openjdk21/commit/3de90bd938a48a6ef285d5a6642d3e2704d10f56)

This is a backport of https://github.com/ibmruntimes/openj9-openjdk-jdk25/pull/40.