### PR TITLE
Fix ProviderFiltering test failure due to OpenJCEPlus in java.base

### DIFF
--- a/test/jdk/java/security/Security/ProviderFiltering.java
+++ b/test/jdk/java/security/Security/ProviderFiltering.java
@@ -36,6 +36,7 @@
  */
 import jdk.test.lib.Utils;
 import java.util.*;
+import java.util.stream.Stream;
 import java.security.*;
 
 public class ProviderFiltering {
@@ -91,13 +92,13 @@ public class ProviderFiltering {
         }
 
         String p = "SUN";
-        List<String> providers = new ArrayList<>();
-        providers.add(p);
-        ModuleLayer.boot().findModule("openjceplus")
-            .ifPresent(m -> providers.add("OpenJCEPlus"));
+        // Get the names of providers in the order they're listed in java.security.
+        String[] providers = Stream.of(Security.getProviders("Signature.NONEwithDSA"))
+                .map(provider -> provider.getName())
+                .toArray(String[]::new);
 
         // test alias
-        doit("Signature.NONEwithDSA", providers.toArray(new String[0]));
+        doit("Signature.NONEwithDSA", providers);
 
         String sigService = "Signature.SHA256withDSA";
         // javadoc allows extra spaces in between
@@ -127,7 +128,7 @@ public class ProviderFiltering {
         // try non-attribute filters
         filters.clear();
         filters.put(sigService, "");
-        doit(filters, providers.toArray(new String[0]));
+        doit(filters, providers);
         filters.put("Cipher.RC2", "");
         doit(filters);
 
@@ -140,10 +141,10 @@ public class ProviderFiltering {
                 customValue);
         Security.insertProviderAt(testProv, 1);
         // should find both TestProv and SUN and in this order
-        providers.add(0, pName);
-        doit(sigService, providers.toArray(new String[0]));
+        providers = Stream.concat(Stream.of(pName), Stream.of(providers)).toArray(String[]::new);
+        doit(sigService, providers);
         filters.put(sigService, "");
-        doit(filters, providers.toArray(new String[0]));
+        doit(filters, providers);
 
         String specAttr = sigService + "  " + customKey + ":" + customValue;
         // should find only TestProv


### PR DESCRIPTION
Port : https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/1198

Signed-off-by: Darshan N [Darshan.N3@ibm.com](mailto:Darshan.N3@ibm.com)