### PR TITLE
Grant Security Manager permissions to OpenJCEPlus

### DIFF
--- a/src/java.base/share/lib/security/default.policy
+++ b/src/java.base/share/lib/security/default.policy
@@ -281,6 +281,16 @@ grant codeBase "jrt:/openj9.gpu" {
     permission java.util.PropertyPermission "com.ibm.gpu.disable", "read";
 };
 
+grant codeBase "jrt:/openjceplus" {
+    permission java.io.FilePermission "<<ALL FILES>>", "read";
+    permission java.lang.RuntimePermission "accessClassInPackage.sun.security.util";
+    permission java.lang.RuntimePermission "loadLibrary.*";
+    permission java.security.SecurityPermission "clearProviderProperties.OpenJCEPlus*";
+    permission java.security.SecurityPermission "putProviderProperty.OpenJCEPlus*";
+    permission java.security.SecurityPermission "removeProviderProperty.OpenJCEPlus*";
+    permission java.util.PropertyPermission "*", "read";
+};
+
 // permissions needed by applications using java.desktop module
 grant {
     permission java.lang.RuntimePermission "accessClassInPackage.com.sun.beans";


### PR DESCRIPTION
Add a scoped policy grant for the OpenJCEPlus module with the minimum permissions required for the provider to load and operate correctly when the Security Manager is enabled.

Since the Security Manager was removed in JDK 25 and later, this PR is intended only for JDK 21 and earlier versions.