### PR TITLE
Ensure JFR periodic task exits promptly during JVM shutdown

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/PlatformRecorder.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/PlatformRecorder.java
@@ -23,6 +23,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2026, 2026 All Rights Reserved
+ * ===========================================================================
+ */
+
 package jdk.jfr.internal;
 
 import static jdk.jfr.internal.LogLevel.ERROR;
@@ -185,6 +191,9 @@ public final class PlatformRecorder {
 
     synchronized void setInShutDown() {
         this.inShutdown = true;
+        synchronized (JVM.CHUNK_ROTATION_MONITOR) {
+            JVM.CHUNK_ROTATION_MONITOR.notifyAll();
+        }
     }
 
     // called by shutdown hook
@@ -526,6 +535,9 @@ public final class PlatformRecorder {
                 // Catch everything and log, but don't allow it to end the periodic task
                 Logger.log(JFR_SYSTEM, ERROR, "Error in Periodic task: " + t.getClass().getName());
             } finally {
+                if (this.inShutdown) {
+                    break;
+                }
                 takeNap(wait);
             }
         }


### PR DESCRIPTION
When running with -Xcheck:memory, the JFR periodic task thread not terminating at shutdown causes terminateRemainingThreads to return non-zero, which bypasses freeJavaVM and results in a large number of reported unfreed memory blocks.

The thread was blocked in takeNap() on JVM.CHUNK_ROTATION_MONITOR with no mechanism to wake promptly when shutdown began. Although PlatformRecorder had an existing inShutdown flag set by the JFR shutdown hook, the periodic task loop did not act on it in time.

Two changes are made:
- setInShutDown() notifies JVM.CHUNK_ROTATION_MONITOR to wake the periodic task immediately if suspended in takeNap().
- periodicTask() checks inShutdown after each work iteration and exits the loop before entering takeNap() if shutdown is requested.

Related Issue: https://github.com/eclipse-openj9/openj9/issues/23980

Back-ported from: https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/1237


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).
