### PR TITLE
Fix SecurityPermission for OpenJCEPlus provider

### DIFF
--- a/src/java.base/share/lib/security/default.policy
+++ b/src/java.base/share/lib/security/default.policy
@@ -285,9 +285,9 @@ grant codeBase "jrt:/openjceplus" {
     permission java.io.FilePermission "<<ALL FILES>>", "read";
     permission java.lang.RuntimePermission "accessClassInPackage.sun.security.util";
     permission java.lang.RuntimePermission "loadLibrary.*";
-    permission java.security.SecurityPermission "clearProviderProperties.OpenJCEPlus*";
-    permission java.security.SecurityPermission "putProviderProperty.OpenJCEPlus*";
-    permission java.security.SecurityPermission "removeProviderProperty.OpenJCEPlus*";
+    permission java.security.SecurityPermission "clearProviderProperties.*";
+    permission java.security.SecurityPermission "putProviderProperty.*";
+    permission java.security.SecurityPermission "removeProviderProperty.*";
     permission java.util.PropertyPermission "*", "read";
 };
 


### PR DESCRIPTION
The policy entry `putProviderProperty.OpenJCEPlus*` does not match `putProviderProperty.OpenJCEPlus` or
`putProviderProperty.OpenJCEPlusFIPS` because `SecurityPermission` inherits its name-matching behaviour from `BasicPermission`.

`BasicPermission` does not support general string-prefix wildcards. A wildcard is recognized only when the permission name is exactly `*` or when `*` appears after a dot, such as `putProviderProperty.*`.

Use the broader permissions `clearProviderProperties.*`, `putProviderProperty.*` and `removeProviderProperty.*` instead.