### PR TITLE
Grant accessClassInPackage.sun.security.* to OpenJCEPlus

### DIFF
--- a/src/java.base/share/lib/security/default.policy
+++ b/src/java.base/share/lib/security/default.policy
@@ -283,7 +283,7 @@ grant codeBase "jrt:/openj9.gpu" {
 
 grant codeBase "jrt:/openjceplus" {
     permission java.io.FilePermission "<<ALL FILES>>", "read";
-    permission java.lang.RuntimePermission "accessClassInPackage.sun.security.util";
+    permission java.lang.RuntimePermission "accessClassInPackage.sun.security.*";
     permission java.lang.RuntimePermission "loadLibrary.*";
     permission java.security.SecurityPermission "clearProviderProperties.*";
     permission java.security.SecurityPermission "putProviderProperty.*";


### PR DESCRIPTION
Grant `accessClassInPackage.sun.security.*` to `jrt:/openjceplus` in `default.policy` to cover sun.security.x509, pkcs, internal.spec, and internal.interfaces required by the OpenJCEPlus provider, and any future need.

Since these are changes to the default policy, they only apply to JDK 21 and earlier versions.