### PR TITLE
Revert "Grant accessClassInPackage.sun.security.* to OpenJCEPlus"

### DIFF
--- a/src/java.base/share/lib/security/default.policy
+++ b/src/java.base/share/lib/security/default.policy
@@ -283,7 +283,7 @@ grant codeBase "jrt:/openj9.gpu" {
 
 grant codeBase "jrt:/openjceplus" {
     permission java.io.FilePermission "<<ALL FILES>>", "read";
-    permission java.lang.RuntimePermission "accessClassInPackage.sun.security.*";
+    permission java.lang.RuntimePermission "accessClassInPackage.sun.security.util";
     permission java.lang.RuntimePermission "loadLibrary.*";
     permission java.security.SecurityPermission "clearProviderProperties.*";
     permission java.security.SecurityPermission "putProviderProperty.*";


### PR DESCRIPTION
Reverts ibmruntimes/openj9-openjdk-jdk21#457.