### PR TITLE
(0.61) Apply freetype/commit/5a280ecde to fix CVE-2026-50811

### DIFF
--- a/src/java.desktop/share/native/libfreetype/src/truetype/ttgxvar.c
+++ b/src/java.desktop/share/native/libfreetype/src/truetype/ttgxvar.c
@@ -3453,9 +3453,7 @@
     TT_Face       ttface = (TT_Face)face;
     FT_Error      error  = FT_Err_Ok;
     GX_Blend      blend;
-    FT_MM_Var*    mmvar;
-    FT_Var_Axis*  a;
-    FT_UInt       i, nc;
+    FT_UInt       i;
 
 
     if ( !ttface->blend )
@@ -3474,30 +3472,27 @@
         return error;
     }
 
-    nc = num_coords;
     if ( num_coords > blend->num_axis )
     {
       FT_TRACE2(( "TT_Get_Var_Design:"
                   " only using first %u of %u coordinates\n",
                   blend->num_axis, num_coords ));
-      nc = blend->num_axis;
+      FT_ARRAY_ZERO( coords + blend->num_axis, num_coords - blend->num_axis );
+      num_coords = blend->num_axis;
     }
 
-    mmvar = blend->mmvar;
-    a     = mmvar->axis;
     if ( ttface->doblend )
     {
-      for ( i = 0; i < nc; i++, a++ )
+      for ( i = 0; i < num_coords; i++ )
         coords[i] = blend->coords[i];
     }
     else
     {
-      for ( i = 0; i < nc; i++, a++ )
-        coords[i] = a->def;
-    }
+      FT_Var_Axis*  a = blend->mmvar->axis;
 
-    for ( ; i < num_coords; i++, a++ )
-      coords[i] = a->def;
+      for ( i = 0; i < num_coords; i++, a++ )
+        coords[i] = a->def;
+      }
 
     return FT_Err_Ok;
   }


### PR DESCRIPTION
https://gitlab.freedesktop.org/freetype/freetype/-/commit/5a280ecde6f324de0d226261036e736e0cb49a71?view=parallel

Backport https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/1249


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).
